### PR TITLE
#850 allow indicator query to be of arbitrary type

### DIFF
--- a/pkg/models/service_indicators.go
+++ b/pkg/models/service_indicators.go
@@ -9,5 +9,5 @@ type ServiceIndicators struct {
 type ServiceIndicator struct {
 	Metric string `json:"metric" yaml:"metric"`
 	Source string `json:"source" yaml:"source"`
-	Query  string `json:"query" yaml:"query"`
+	Query  interface{} `json:"query" yaml:"query"`
 }


### PR DESCRIPTION
This is to support any type of indicator source, not only prometheus