### PR TITLE
Update readme to direct people to the main keptn repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Go-utils
+# Keptn go-utils
 
-This repo serves as a util package for common functionalities such as logging.
+This repo serves as a util package for common functionalities such as logging of the [Keptn Project](https://github.com/keptn).
+
+Please post any issues with this package to the [keptn/keptn repository](https://github.com/keptn/keptn/issues) and label them with `area:go-utils`.
 
 ## Usage
 


### PR DESCRIPTION
For now we want users to open issues in the keptn/keptn repo.

I've also made it clear in the REAMDE that this repository contains the go-utils for the Keptn project.