### PR TITLE
Add more information about json parse errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+.idea/
+.code/
+
 vendor/

--- a/pkg/api/utils/apiServiceUtils.go
+++ b/pkg/api/utils/apiServiceUtils.go
@@ -38,12 +38,14 @@ func post(uri string, data []byte, api APIService) (*models.ChannelInfo, *models
 	}
 
 	if resp.StatusCode == 200 {
+		// api returned status 200 -> unmarshal json response
 
 		if len(body) > 0 {
 			var channelInfo models.ChannelInfo
 			err = json.Unmarshal(body, &channelInfo)
 			if err != nil {
-				return nil, buildErrorResponse(err.Error())
+				// failed to parse json
+				return nil, buildErrorResponse(err.Error() + "\n" + "-----DETAILS-----" + string(body))
 			}
 			return &channelInfo, nil
 		}
@@ -54,7 +56,8 @@ func post(uri string, data []byte, api APIService) (*models.ChannelInfo, *models
 	var respErr models.Error
 	err = json.Unmarshal(body, &respErr)
 	if err != nil {
-		return nil, buildErrorResponse(err.Error())
+		// failed to parse json
+		return nil, buildErrorResponse(err.Error() + "\n" + "-----DETAILS-----" + string(body))
 	}
 
 	return nil, &respErr
@@ -83,7 +86,8 @@ func delete(uri string, api APIService) (*models.ChannelInfo, *models.Error) {
 			var channelInfo models.ChannelInfo
 			err = json.Unmarshal(body, &channelInfo)
 			if err != nil {
-				return nil, buildErrorResponse(err.Error())
+				// failed to parse json
+				return nil, buildErrorResponse(err.Error() + "\n" + "-----DETAILS-----" + string(body))
 			}
 			return &channelInfo, nil
 		}
@@ -94,7 +98,8 @@ func delete(uri string, api APIService) (*models.ChannelInfo, *models.Error) {
 	var respErr models.Error
 	err = json.Unmarshal(body, &respErr)
 	if err != nil {
-		return nil, buildErrorResponse(err.Error())
+		// failed to parse json
+		return nil, buildErrorResponse(err.Error() + "\n" + "-----DETAILS-----" + string(body))
 	}
 
 	return nil, &respErr


### PR DESCRIPTION
I have an undebuggable issue on travis-CI when authenticating with keptn, where the API seems to not return JSON.
The error message displayed is: ``unexpected end of JSON input``

My guess is that this is an issue with istio or a loadbalancer or alike. To be 100% sure, I've added a proper debug output of the body.

Also, we can never be 100% sure that the response contains proper JSON. 