### PR TITLE
#950 fix success:false should not be ommitted

### DIFF
--- a/pkg/events/keptnEvents.go
+++ b/pkg/events/keptnEvents.go
@@ -222,7 +222,7 @@ type SLIFilter struct {
 type SLIResult struct {
 	Metric  string  `json:"metric"`
 	Value   float64 `json:"value"`
-	Success bool    `json:"success,omitempty"`
+	Success bool    `json:"success"`
 	Message string  `json:"message,omitempty"`
 }
 


### PR DESCRIPTION
During testing I noticed that when setting `success: false` for SLI Results is not populated within JSON.

As a user I would expect `success: false` to be shown in the result if something failed.