### PR TITLE
#1053 added SLO config to evaluationdetails and restructured eval details

### DIFF
--- a/pkg/events/keptnEvents.go
+++ b/pkg/events/keptnEvents.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	v2 "github.com/keptn/go-utils/pkg/models/v2"
 )
 
 // InternalProjectCreateEventType is a CloudEvent type for creating a new project
@@ -178,11 +179,12 @@ type EvaluationDoneEventData struct {
 }
 
 type EvaluationDetails struct {
-	TimeStart        string                 `json:"timeStart"`
-	TimeEnd          string                 `json:"timeEnd"`
-	Result           string                 `json:"result"`
-	Score            float64                `json:"score"`
-	IndicatorResults []*SLIEvaluationResult `json:"indicatorResults"`
+	TimeStart              string                    `json:"timeStart"`
+	TimeEnd                string                    `json:"timeEnd"`
+	Result                 string                    `json:"result"`
+	Score                  float64                   `json:"score"`
+	ServiceLevelObjectives v2.ServiceLevelObjectives `json:"serviceLevelObjectives"`
+	IndicatorResults       []*SLIEvaluationResult    `json:"indicatorResults"`
 }
 
 type SLIFilter struct {
@@ -198,15 +200,16 @@ type SLIResult struct {
 }
 
 type SLIEvaluationResult struct {
-	Score      float64         `json:"score"`
-	Value      *SLIResult      `json:"value"`
-	Violations []*SLIViolation `json:"violations"`
-	Status     string          `json:"status"` // pass | warning | fail
+	Score   float64      `json:"score"`
+	Value   *SLIResult   `json:"value"`
+	Targets []*SLITarget `json:"targets"`
+	Status  string       `json:"status"` // pass | warning | fail
 }
 
-type SLIViolation struct {
+type SLITarget struct {
 	Criteria    string  `json:"criteria"`
 	TargetValue float64 `json:"targetValue"`
+	Violated    bool    `json:"violated"`
 }
 
 // ProblemEventData represents the data for describing a problem


### PR DESCRIPTION
in the evaluation results, now all evaluated criteria and their target values are listed, instead of just the violations