### PR TITLE
Added automation for PRs to Keptn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
 
     - stage: Auto PR To Keptn
       os: linux
-      if: branch = master or tag IS present
+      if: not type = pull_request and (branch = master or tag IS present)
       before_script:
         - git config --global user.email "go-utils@keptn.sh"
         - git config --global user.name "go-utils"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,73 @@ dist: xenial
 language: go
 
 go:
-- 1.12.x
+  - 1.12.x
 
 # Don't email me the results of the test runs.
 notifications:
   email: false
 
 env:
-- GO111MODULE=on
+  global:
+    - GO111MODULE=on
+    - GOPROXY=https://proxy.golang.org
 
 # enable module cache
 cache:
   directories:
-    - $GOPATH/pkg/mod  
+    - $GOPATH/pkg/mod
+    - ../keptn
 
-# script always runs to completion (set +e). If we have linter issues AND a
-# failing test, we want to see both. Configure golangci-lint with a
-# .golangci.yml file at the top level of your repo.
-script:
-  - go test -v -race ./...  # Run all the tests with the race detector enabled
+jobs:
+  include:
+    - stage: tests
+      os: linux
+      script:
+        - go test -v -race ./...  # Run all the tests with the race detector enabled
+
+    - stage: Auto PR To Keptn
+      os: linux
+      if: branch = master or tag IS present
+      before_script:
+        - git config --global user.email "go-utils@keptn.sh"
+        - git config --global user.name "go-utils"
+        # figure out if this is a tag
+        - |
+          GO_UTILS_TARGET=$TRAVIS_COMMIT
+          if [[ $TRAVIS_TAG -ne "" ]]; then
+            GO_UTILS_TARGET=$TRAVIS_TAG
+          fi
+      script:
+        - cd ..
+        # clone Keptn repo
+        - git clone https://${GITHUB_TOKEN}@github.com/keptn/keptn.git
+        - cd keptn
+        # checkout master and ensure we are up2date
+        - git checkout master
+        - git pull
+        - export TARGET_BRANCH=patch/1/update_go_utils
+        # delete existing branch just in case
+        - git branch -D $TARGET_BRANCH &>/dev/null
+        # create a new branch
+        - git checkout -b $TARGET_BRANCH
+        # update go modules in all directories that contain go.mod
+        - |
+          for file in *; do
+             if [[ -f "$file/go.mod" ]]; then
+                 echo "Checking if $file/go.mod contains go-utils"
+                 grep go-utils $file/go.mod
+                 if [[ $? -eq 0 ]]; then
+                      echo "Yes, updating go-utils now..."
+                      cd $file
+                      go get "github.com/keptn/go-utils@$GO_UTILS_TARGET"
+                      cd ..
+                 fi
+             fi
+          done
+        - git status
+        # add changes to a new commit
+        - git add .
+        - git commit -m "Update keptn/go-utils to $GO_UTILS_TARGET"
+        - git push -f origin $TARGET_BRANCH
+        - |
+          curl -XPOST -H "Authorization: token $GITHUB_TOKEN" -d "{\"title\":\"Auto-update go-utils to latest version\", \"base\":\"master\", \"head\":\"$TARGET_BRANCH\", \"body\":\"This is an automatically created PR to change keptn/go-utils to version $GO_UTILS_TARGET.\"}" https://api.github.com/repos/keptn/keptn/pulls

--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ import {
 	keptnmodels "github.com/keptn/go-utils/pkg/models"
 )
 ```
+
+## Automation
+
+Within [.travis.yml](.travis.yml) we have included an automation that creates a Pull Request to 
+ [github.com/keptn/keptn](https://github.com/keptn/keptn) to update `go.mod` files with an updated version of this 
+ package (based on the commit hash). To make this work, a `GITHUB_TOKEN` (personal access token) 
+ needs to be added within the [travis-ci settings page](https://travis-ci.org/keptn/go-utils/settings).


### PR DESCRIPTION
I've changed .travis.yml such that it would automatically create a PR on keptn/keptn for all sub-directories that contain a file called `go.mod` which contains `go-utils`.

The resulting PR looks like this: https://github.com/keptn/keptn/pull/1427

I've set it up such that if we create a new tag (e.g., v0.6.1), the script should use the tag instead of the commit hash (though we'd have to try that out).