### PR TITLE
Fix api endpoint

### DIFF
--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -90,7 +90,7 @@ func (s *StageHandler) GetAllStages(project string) ([]*models.Stage, error) {
 
 	nextPageKey := ""
 	for {
-		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/v1/project/" + project + "/stage")
+		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/configuration-service/v1/project/" + project + "/stage")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -44,6 +44,7 @@ func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader s
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
+	httpClient.Transport = getClientTransport()
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	return &StageHandler{


### PR DESCRIPTION
Hi,

while trying to implement https://github.com/keptn/keptn/issues/1624 I could not get alls stages for a project with

```
stagesHandler := apiutils.NewAuthenticatedStageHandler(endPoint.String(), apiToken, "x-token", nil, *scheme)
stages, err := stagesHandler.GetAllStages(*projectName.project)
```

Looks like the API Url is wrong (in projectUtils.go it's already using the /configuration-service/ URL).

I've adjusted the URL and tested locally, seems to be working.

I don't know if this is an issue as well, but in the projectUtils.go and serviceUtils.go there is the httpClient.Transport = getClientTransport() while in the stageUtils.go it is not.

projectUtils.go
```
func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
	if httpClient == nil {
		httpClient = &http.Client{}
	}
	httpClient.Transport = getClientTransport()

	baseURL = strings.TrimPrefix(baseURL, "http://")
	baseURL = strings.TrimPrefix(baseURL, "https://")
```

stageUtils.go
```
func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
	if httpClient == nil {
		httpClient = &http.Client{}
	}
	baseURL = strings.TrimPrefix(baseURL, "http://")
	baseURL = strings.TrimPrefix(baseURL, "https://")
```