### PR TITLE
added event type filter to request params

### DIFF
--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -113,6 +113,9 @@ func (e *EventHandler) GetEvents(filter *EventFilter) ([]*models.KeptnContextExt
 	if filter.EventID != "" {
 		query.Set("eventID", filter.EventID)
 	}
+	if filter.EventType != "" {
+		query.Set("type", filter.EventType)
+	}
 
 	u.RawQuery = query.Encode()
 


### PR DESCRIPTION
The event type filter was not set properly in the `GetEvents()` function