### PR TITLE
fixed struct of action.triggered event; added constants for result info

### DIFF
--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -419,6 +419,18 @@ type ProblemDetails struct {
 	Tags string `json:"Tags,omitempty"`
 }
 
+// ActionInfo contains information about the action to be performed
+type ActionInfo struct {
+	// Name is the name of the action
+	Name string `json:"name"`
+	// Action determines the type of action to be executed
+	Action string `json:"action"`
+	// Description contains the description of the action
+	Description string `json:"description"`
+	// Values contains additional values
+	Values map[string]string `json:"values"`
+}
+
 // ActionTriggeredEventData contains information about an action.triggered event
 type ActionTriggeredEventData struct {
 	// Project is the name of the project
@@ -431,11 +443,24 @@ type ActionTriggeredEventData struct {
 	Action string `json:"action"`
 	// Problem contains details about the problem
 	Problem ProblemDetails `json:"problem"`
-	// Values contains additional values
-	Values map[string]string `json:"values"`
 	// Labels contains labels
 	Labels map[string]string `json:"labels"`
 }
+
+type ActionResultType string
+
+const (
+	ActionResultPass   ActionResultType = "pass"
+	ActionResultFailed ActionResultType = "failed"
+)
+
+type ActionStatusType string
+
+const (
+	ActionStatusSucceeded ActionStatusType = "succeeded"
+	ActionStatusErrored   ActionStatusType = "errored"
+	ActionStatusUnknown   ActionStatusType = "unknown"
+)
 
 // ActionResult contains information about the execution of an action
 type ActionResult struct {

--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -464,8 +464,8 @@ const (
 
 // ActionResult contains information about the execution of an action
 type ActionResult struct {
-	Result string `json:"result"`
-	Status string `json:"status"`
+	Result ActionResultType `json:"result"`
+	Status ActionStatusType `json:"status"`
 }
 
 // ActionFinishedEventData contains information about the execution of an action

--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -440,7 +440,7 @@ type ActionTriggeredEventData struct {
 	// Stage is the name of the stage
 	Stage string `json:"stage"`
 	// Action describes the type of action
-	Action string `json:"action"`
+	Action ActionInfo `json:"action"`
 	// Problem contains details about the problem
 	Problem ProblemDetails `json:"problem"`
 	// Labels contains labels


### PR DESCRIPTION
The struct for the `action.triggered` event implemented in PR #162 did not contain the correct definition for the `action` property. Additionally, constants for the result/status of an action have been added.