### PR TITLE
#1816 fixed struct of action.triggered event

### DIFF
--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -428,7 +428,7 @@ type ActionInfo struct {
 	// Description contains the description of the action
 	Description string `json:"description"`
 	// Value contains the value of the action
-	Value interface{} `json:"values"`
+	Value interface{} `json:"value"`
 }
 
 // ActionTriggeredEventData contains information about an action.triggered event

--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -428,7 +428,7 @@ type ActionInfo struct {
 	// Description contains the description of the action
 	Description string `json:"description"`
 	// Value contains the value of the action
-	Value interface{} `json:"value"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // ActionTriggeredEventData contains information about an action.triggered event

--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -427,8 +427,8 @@ type ActionInfo struct {
 	Action string `json:"action"`
 	// Description contains the description of the action
 	Description string `json:"description"`
-	// Values contains additional values
-	Values map[string]string `json:"values"`
+	// Value contains the value of the action
+	Value interface{} `json:"values"`
 }
 
 // ActionTriggeredEventData contains information about an action.triggered event


### PR DESCRIPTION
changed the type of `Value` of the action definition to `interface{}` to be more flexible