### PR TITLE
#1861 Fix configuration-service URL

### DIFF
--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -39,6 +39,8 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 	}
 }
 
+const configurationServiceBaseUrl = "configuration-service"
+
 // NewAuthenticatedProjectHandler returns a new ProjectHandler that authenticates at the endpoint via the provided token
 func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
 	if httpClient == nil {
@@ -48,6 +50,10 @@ func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
+	baseURL = strings.TrimRight(baseURL, "/")
+	if !strings.HasSuffix(baseURL, configurationServiceBaseUrl) {
+		baseURL += "/" + configurationServiceBaseUrl
+	}
 	return &ProjectHandler{
 		BaseURL:    baseURL,
 		AuthHeader: authHeader,
@@ -97,7 +103,7 @@ func (p *ProjectHandler) DeleteProject(project models.Project) (*models.EventCon
 
 // GetProject returns a project
 func (p *ProjectHandler) GetProject(project models.Project) (*models.Project, *models.Error) {
-	return getProject(p.Scheme+"://"+p.getBaseURL()+"/configuration-service/v1/project/"+project.ProjectName, p)
+	return getProject(p.Scheme+"://"+p.getBaseURL()+"/v1/project/"+project.ProjectName, p)
 }
 
 // GetProjects returns a project
@@ -108,7 +114,7 @@ func (p *ProjectHandler) GetAllProjects() ([]*models.Project, error) {
 	nextPageKey := ""
 
 	for {
-		url, err := url.Parse(p.Scheme + "://" + p.getBaseURL() + "/configuration-service/v1/project/")
+		url, err := url.Parse(p.Scheme + "://" + p.getBaseURL() + "/v1/project/")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -54,6 +54,10 @@ func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeade
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
+	baseURL = strings.TrimRight(baseURL, "/")
+	if !strings.HasSuffix(baseURL, configurationServiceBaseUrl) {
+		baseURL += "/" + configurationServiceBaseUrl
+	}
 	return &ResourceHandler{
 		BaseURL:    baseURL,
 		AuthHeader: authHeader,

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -48,6 +48,11 @@ func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
+
+	baseURL = strings.TrimRight(baseURL, "/")
+	if !strings.HasSuffix(baseURL, configurationServiceBaseUrl) {
+		baseURL += "/" + configurationServiceBaseUrl
+	}
 	return &ServiceHandler{
 		BaseURL:    baseURL,
 		AuthHeader: authHeader,
@@ -96,7 +101,7 @@ func (s *ServiceHandler) CreateServiceInStage(project string, stage string, serv
 func (s *ServiceHandler) GetService(project, stage, service string) (*models.Service, error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/configuration-service/v1/project/" + project + "/stage/" + stage + "/service/" + service)
+	url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/v1/project/" + project + "/stage/" + stage + "/service/" + service)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +146,7 @@ func (s *ServiceHandler) GetAllServices(project string, stage string) ([]*models
 	nextPageKey := ""
 
 	for {
-		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/configuration-service/v1/project/" + project + "/stage/" + stage + "/service")
+		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/v1/project/" + project + "/stage/" + stage + "/service")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -47,6 +47,11 @@ func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader s
 	httpClient.Transport = getClientTransport()
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
+
+	baseURL = strings.TrimRight(baseURL, "/")
+	if !strings.HasSuffix(baseURL, configurationServiceBaseUrl) {
+		baseURL += "/" + configurationServiceBaseUrl
+	}
 	return &StageHandler{
 		BaseURL:    baseURL,
 		AuthHeader: authHeader,
@@ -91,7 +96,7 @@ func (s *StageHandler) GetAllStages(project string) ([]*models.Stage, error) {
 
 	nextPageKey := ""
 	for {
-		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/configuration-service/v1/project/" + project + "/stage")
+		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + "/v1/project/" + project + "/stage")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR fixes https://github.com/keptn/keptn/issues/1861.

Applied rule:
- If the go-utils user creates an **authenticated** handler, we use the configuration-service URL suitable for the api-gateway-nginx (i.e. containing `/configuration-service` as prefix).
- If the go-utils user creates a normal handler, we use the **internal** configuration-service URL.