### PR TITLE
#1607 create a logger when a Keptn Handler is being initialized

### DIFF
--- a/pkg/lib/combined_logger.go
+++ b/pkg/lib/combined_logger.go
@@ -54,6 +54,7 @@ func (l *CombinedLogger) Terminate() {
 	if err := WriteLog(l.ws, LogData{LogLevel: "INFO", Message: "", Terminate: true}, l.shKeptnContext); err != nil {
 		l.logWebsocketError(err)
 	}
+	l.ws.Close()
 }
 
 func (l *CombinedLogger) logWebsocketError(err error) {

--- a/pkg/lib/keptn_test.go
+++ b/pkg/lib/keptn_test.go
@@ -21,6 +21,7 @@ func TestNewKeptn(t *testing.T) {
 	incomingEvent.SetSource("test")
 	incomingEvent.SetExtension("shkeptncontext", "test-context")
 	incomingEvent.SetDataContentType(cloudevents.ApplicationCloudEventsJSON)
+	incomingEvent.SetID("test-id")
 
 	keptnBase := &KeptnBase{
 		Project:            "sockshop",
@@ -74,6 +75,7 @@ func TestNewKeptn(t *testing.T) {
 					HTTPClient: nil,
 					Scheme:     "",
 				},
+				Logger: NewLogger("test-context", "test-id", "keptn"),
 			},
 		},
 		{
@@ -114,6 +116,7 @@ func TestNewKeptn(t *testing.T) {
 					HTTPClient: nil,
 					Scheme:     "",
 				},
+				Logger: NewLogger("test-context", "test-id", "keptn"),
 			},
 		},
 		{
@@ -154,6 +157,7 @@ func TestNewKeptn(t *testing.T) {
 					HTTPClient: nil,
 					Scheme:     "",
 				},
+				Logger: NewLogger("test-context", "test-id", "keptn"),
 			},
 		},
 		{
@@ -194,6 +198,51 @@ func TestNewKeptn(t *testing.T) {
 					HTTPClient: nil,
 					Scheme:     "",
 				},
+				Logger: NewLogger("test-context", "test-id", "keptn"),
+			},
+		},
+		{
+			name: "Get Keptn with custom logger",
+			args: args{
+				incomingEvent: &incomingEvent,
+				opts: KeptnOpts{
+					UseLocalFileSystem:      false,
+					ConfigurationServiceURL: "custom-config:8080",
+					EventBrokerURL:          "custom-eb:8080",
+					LoggingOptions: &LoggingOpts{
+						ServiceName: stringp("my-service"),
+					},
+				},
+			},
+			want: &Keptn{
+				KeptnBase: &KeptnBase{
+					Project:            "sockshop",
+					Stage:              "dev",
+					Service:            "carts",
+					TestStrategy:       nil,
+					DeploymentStrategy: nil,
+					Tag:                nil,
+					Image:              nil,
+					Labels:             nil,
+				},
+				KeptnContext:       "test-context",
+				eventBrokerURL:     "custom-eb:8080",
+				useLocalFileSystem: false,
+				resourceHandler: &api.ResourceHandler{
+					BaseURL:    "custom-config:8080",
+					AuthHeader: "",
+					AuthToken:  "",
+					HTTPClient: &http.Client{},
+					Scheme:     "http",
+				},
+				eventHandler: &api.EventHandler{
+					BaseURL:    "custom-config:8080",
+					AuthToken:  "",
+					AuthHeader: "",
+					HTTPClient: nil,
+					Scheme:     "",
+				},
+				Logger: NewLogger("test-context", "test-id", "my-service"),
 			},
 		},
 	}


### PR DESCRIPTION
This PR is part of [#1607](https://github.com/keptn/issues/1607).
When a Keptn Handler is being initialized, a logger is automatically initialized. By default, a standard logger that only prints to stdout is initialized. There is also an option to create a WebSocket logger, based on the Websocket connection info within the data block of the incoming CloudEvent. By default, when connecting to a WebSocket server, the endpoint is set to `ws://api-service.keptn.svc.cluster.local:8080`. This can be overriden in the options provided to the `NewKeptn` function. Example:

```
serviceNameForLogging := "my-service"
customWebsocketEndpoint := "ws://my-custom-endpoint"
keptnHandler, _ := keptn.NewKeptn(incomingCloudEvent, &KeptnOpts{
					UseLocalFileSystem:      false,
					ConfigurationServiceURL: "custom-config:8080",
					EventBrokerURL:          "custom-eb:8080",
					LoggingOptions: &LoggingOpts{
						ServiceName: &serviceNameForLogging,
                                               EnableWebsocket: true,
                                               WebsocketEndpoint: &customWebsocketEndpoint,
					},
				})
```