### PR TITLE
#1881 Introduce apiUtils 

### DIFF
--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/keptn/go-utils/pkg/api/models"
+)
+
+// APIHandler handles projects
+type APIHandler struct {
+	BaseURL    string
+	AuthToken  string
+	AuthHeader string
+	HTTPClient *http.Client
+	Scheme     string
+}
+
+// NewAuthenticatedAPIHandler returns a new APIHandler that authenticates at the api-service endpoint via the provided token
+func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	httpClient.Transport = getClientTransport()
+
+	baseURL = strings.TrimPrefix(baseURL, "http://")
+	baseURL = strings.TrimPrefix(baseURL, "https://")
+	return &APIHandler{
+		BaseURL:    baseURL,
+		AuthHeader: authHeader,
+		AuthToken:  authToken,
+		HTTPClient: httpClient,
+		Scheme:     scheme,
+	}
+}
+
+func (p *APIHandler) getBaseURL() string {
+	return p.BaseURL
+}
+
+func (p *APIHandler) getAuthToken() string {
+	return p.AuthToken
+}
+
+func (p *APIHandler) getAuthHeader() string {
+	return p.AuthHeader
+}
+
+func (p *APIHandler) getHTTPClient() *http.Client {
+	return p.HTTPClient
+}
+
+// CreateProject creates a new project
+func (p *APIHandler) CreateProject(project models.CreateProject) (*models.EventContext, *models.Error) {
+	bodyStr, err := json.Marshal(project)
+	if err != nil {
+		return nil, buildErrorResponse(err.Error())
+	}
+	return post(p.Scheme+"://"+p.getBaseURL()+"/v1/project", bodyStr, p)
+}
+
+// DeleteProject deletes a project
+func (p *APIHandler) DeleteProject(project models.Project) (*models.EventContext, *models.Error) {
+	return delete(p.Scheme+"://"+p.getBaseURL()+"/v1/project/"+project.ProjectName, p)
+}
+
+// CreateService creates a new service
+func (s *APIHandler) CreateService(project string, service models.CreateService) (*models.EventContext, *models.Error) {
+	bodyStr, err := json.Marshal(service)
+	if err != nil {
+		return nil, buildErrorResponse(err.Error())
+	}
+	return post(s.Scheme+"://"+s.getBaseURL()+"/v1/project/"+project+"/service", bodyStr, s)
+}

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -21,7 +21,7 @@ type ProjectHandler struct {
 	Scheme     string
 }
 
-// NewProjectHandler returns a new ProjectHandler
+// NewProjectHandler returns a new ProjectHandler which sends all requests directly to the configuration-service
 func NewProjectHandler(baseURL string) *ProjectHandler {
 	scheme := "http"
 	if strings.Contains(baseURL, "https://") {
@@ -41,7 +41,8 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 
 const configurationServiceBaseUrl = "configuration-service"
 
-// NewAuthenticatedProjectHandler returns a new ProjectHandler that authenticates at the endpoint via the provided token
+// NewAuthenticatedProjectHandler returns a new ProjectHandler that authenticates at the api via the provided token
+// and sends all requests directly to the configuration-service
 func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
@@ -80,15 +81,7 @@ func (p *ProjectHandler) getHTTPClient() *http.Client {
 }
 
 // CreateProject creates a new project
-func (p *ProjectHandler) CreateProject(project models.CreateProject) (*models.EventContext, *models.Error) {
-	bodyStr, err := json.Marshal(project)
-	if err != nil {
-		return nil, buildErrorResponse(err.Error())
-	}
-	return post(p.Scheme+"://"+p.getBaseURL()+"/v1/project", bodyStr, p)
-}
-
-func (p *ProjectHandler) CreateConfigurationServiceProject(project models.Project) (*models.EventContext, *models.Error) {
+func (p *ProjectHandler) CreateProject(project models.Project) (*models.EventContext, *models.Error) {
 	bodyStr, err := json.Marshal(project)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -27,7 +27,7 @@ type resourceRequest struct {
 	Resources []*models.Resource `json:"resources"`
 }
 
-// NewResourceHandler returns a new ResourceHandler
+// NewResourceHandler returns a new ResourceHandler which sends all requests directly to the configuration-service
 func NewResourceHandler(baseURL string) *ResourceHandler {
 	scheme := "http"
 	if strings.Contains(baseURL, "https://") {
@@ -45,7 +45,8 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 	}
 }
 
-// NewAuthenticatedResourceHandler returns a new ResourceHandler that authenticates at the endpoint via the provided token
+// NewAuthenticatedResourceHandler returns a new ResourceHandler that authenticates at the api via the provided token
+// and sends all requests directly to the configuration-service
 func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ResourceHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -21,7 +21,7 @@ type ServiceHandler struct {
 	Scheme     string
 }
 
-// NewServiceHandler returns a new ServiceHandler
+// NewServiceHandler returns a new ServiceHandler which sends all requests directly to the configuration-service
 func NewServiceHandler(baseURL string) *ServiceHandler {
 	scheme := "http"
 	if strings.Contains(baseURL, "https://") {
@@ -39,7 +39,8 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 	}
 }
 
-// NewAuthenticatedServiceHandler returns a new ServiceHandler that authenticates at the endpoint via the provided token
+// NewAuthenticatedServiceHandler returns a new ServiceHandler that authenticates at the api via the provided token
+// and sends all requests directly to the configuration-service
 func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ServiceHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
@@ -76,15 +77,6 @@ func (s *ServiceHandler) getAuthHeader() string {
 
 func (s *ServiceHandler) getHTTPClient() *http.Client {
 	return s.HTTPClient
-}
-
-// CreateService creates a new service
-func (s *ServiceHandler) CreateService(project string, service models.CreateService) (*models.EventContext, *models.Error) {
-	bodyStr, err := json.Marshal(service)
-	if err != nil {
-		return nil, buildErrorResponse(err.Error())
-	}
-	return post(s.Scheme+"://"+s.getBaseURL()+"/v1/project/"+project+"/service", bodyStr, s)
 }
 
 // CreateService creates a new service

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -21,7 +21,7 @@ type StageHandler struct {
 	Scheme     string
 }
 
-// NewStageHandler returns a new StageHandler
+// NewStageHandler returns a new StageHandler which sends all requests directly to the configuration-service
 func NewStageHandler(baseURL string) *StageHandler {
 	scheme := "http"
 	if strings.Contains(baseURL, "https://") {
@@ -39,7 +39,8 @@ func NewStageHandler(baseURL string) *StageHandler {
 	}
 }
 
-// NewAuthenticatedStageHandler returns a new StageHandler that authenticates at the endpoint via the provided token
+// NewAuthenticatedStageHandler returns a new StageHandler that authenticates at the api via the provided token
+// and sends all requests directly to the configuration-service
 func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}


### PR DESCRIPTION
**Status:**
In the Keptn API, the `api-service` and the `configuration-service` provide endpoints with the same paths. However, their implementation is different, which led to confusion.

In order to allow a clear distinction also in the go-utils helper function, this PR introduces a new handler, which handles requests for the `api-service` (i.e. POSTs and DELETEs on projects and POSTs on services).