### PR TITLE
#1815 Move triggeredid into header

### DIFF
--- a/pkg/api/models/keptn_context_extended_c_e.go
+++ b/pkg/api/models/keptn_context_extended_c_e.go
@@ -43,6 +43,9 @@ type KeptnContextExtendedCE struct {
 	// Format: date-time
 	Time strfmt.DateTime `json:"time,omitempty"`
 
+	// triggeredid
+	Triggeredid string `json:"triggeredid,omitempty"`
+
 	// type
 	// Required: true
 	Type *string `json:"type"`

--- a/pkg/lib/events.go
+++ b/pkg/lib/events.go
@@ -356,9 +356,8 @@ type InternalGetSLIDoneEventData struct {
 }
 
 type ApprovalData struct {
-	TriggeredID string `json:"triggered_id"`
-	Result      string `json:"result"`
-	Status      string `json:"status"`
+	Result string `json:"result"`
+	Status string `json:"status"`
 }
 
 // ApprovalTriggeredEventData contains information about an approval.triggered event


### PR DESCRIPTION
Addresses https://github.com/keptn/keptn/issues/1815
In order to be spec-compliant, the triggeredid is moved into the CloudEvents context.