### PR TITLE
#1919 Use apiVersion for Remediation types, re-organize package structure

### DIFF
--- a/pkg/lib/remediations.go
+++ b/pkg/lib/remediations.go
@@ -1,47 +1,21 @@
 package keptn
 
 // Remediations contains remediation definitions for a service
+// Deprecated: A new spec for Remediations is available
 type Remediations struct {
 	Remediations []*Remediation `json:"remediations" yaml:"remediations"`
 }
 
 // Remediation represents a remediation
+// Deprecated: A new spec for Remediation is available
 type Remediation struct {
 	Name    string               `json:"name" yaml:"name"`
 	Actions []*RemediationAction `json:"actions" yaml:"actions"`
 }
 
 // RemediationAction represents a remediation action
+// Deprecated: A new spec for RemediationAction is available
 type RemediationAction struct {
 	Action string `json:"action" yaml:"action"`
 	Value  string `json:"value" yaml:"value"`
-}
-
-///// v0.2.0 Remediation Spec ///////
-
-// RemediationV02 describes a remediation specification according to Keptn spec 0.7.0
-type RemediationV02 struct {
-	Version  string                 `json:"version" yaml:"version"`
-	Kind     string                 `json:"kind" yaml:"kind"`
-	Metadata RemediationV02Metadata `json:"metadata" yaml:"metadata"`
-	Spec     RemediationV02Spec     `json:"spec" yaml:"spec"`
-}
-
-// RemediationV02Metadata describes Remediation metadata
-type RemediationV02Metadata struct {
-	Name string `json:"name" yaml:"name"`
-}
-
-type RemediationV02ActionsOnOpen struct {
-	Name        string      `json:"name" yaml:"name"`
-	Action      string      `json:"action" yaml:"action"`
-	Description string      `json:"description" yaml:"description"`
-	Value       interface{} `json:"value" yaml:"value"`
-}
-type RemediationV02Remediations struct {
-	ProblemType   string                        `json:"problemType" yaml:"problemType"`
-	ActionsOnOpen []RemediationV02ActionsOnOpen `json:"actionsOnOpen" yaml:"actionsOnOpen"`
-}
-type RemediationV02Spec struct {
-	Remediations []RemediationV02Remediations `json:"remediations" yaml:"remediations"`
 }

--- a/pkg/lib/v0_1_3/remediations.go
+++ b/pkg/lib/v0_1_3/remediations.go
@@ -1,0 +1,35 @@
+package v0_1_3
+
+///// v0.1.3 Remediation Spec ///////
+
+// Remediation describes a remediation specification according to Keptn spec 0.1.3
+type Remediation struct {
+	ApiVersion string              `json:"apiVersion" yaml:"version"`
+	Kind       string              `json:"kind" yaml:"kind"`
+	Metadata   RemediationMetadata `json:"metadata" yaml:"metadata"`
+	Spec       RemediationSpec     `json:"spec" yaml:"spec"`
+}
+
+// RemediationMetadata describes Remediation metadata
+type RemediationMetadata struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// RemediationActionsOnOpen describes an action which is executed when a problem.open occurred
+type RemediationActionsOnOpen struct {
+	Name        string      `json:"name" yaml:"name"`
+	Action      string      `json:"action" yaml:"action"`
+	Description string      `json:"description" yaml:"description"`
+	Value       interface{} `json:"value" yaml:"value"`
+}
+
+// RemediationMap maps a problem to a list of actions which are executed when a problem.open occurred
+type RemediationMap struct {
+	ProblemType   string                     `json:"problemType" yaml:"problemType"`
+	ActionsOnOpen []RemediationActionsOnOpen `json:"actionsOnOpen" yaml:"actionsOnOpen"`
+}
+
+// RemediationSpec contains a list of remediations
+type RemediationSpec struct {
+	Remediations []RemediationMap `json:"remediations" yaml:"remediations"`
+}

--- a/pkg/lib/v0_1_4/remediations.go
+++ b/pkg/lib/v0_1_4/remediations.go
@@ -1,8 +1,8 @@
-package v0_1_3
+package v0_1_4
 
-///// v0.1.3 Remediation Spec ///////
+///// v0.1.4 Remediation Spec ///////
 
-// Remediation describes a remediation specification according to Keptn spec 0.1.3
+// Remediation describes a remediation specification according to Keptn spec 0.1.4
 type Remediation struct {
 	ApiVersion string              `json:"apiVersion" yaml:"version"`
 	Kind       string              `json:"kind" yaml:"kind"`


### PR DESCRIPTION
This PR prepares https://github.com/keptn/keptn/issues/1919

More precisely, this PR 
- replaces the field `version` with `apiVersion` in the remediation type and
- reorganizes the package structure, i.e. moves the `spec.keptn.sh/0.1.3`-compatible remediation types into the folder `v0_1_3`.