### PR TITLE
Added page size parameter to event filter

### DIFF
--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -28,6 +28,7 @@ type EventFilter struct {
 	EventType    string
 	KeptnContext string
 	EventID      string
+	PageSize	 string
 }
 
 // NewEventHandler returns a new EventHandler
@@ -114,6 +115,9 @@ func (e *EventHandler) GetEvents(filter *EventFilter) ([]*models.KeptnContextExt
 	}
 	if filter.EventType != "" {
 		query.Set("type", filter.EventType)
+	}
+	if filter.PageSize != "" {
+		query.Set("pageSize", filter.PageSize)
 	}
 
 	u.RawQuery = query.Encode()


### PR DESCRIPTION
- Passing page size parameter to `getEvents` function for controlling the number of returned events