### PR TITLE
#1655 set error code to 404 if no event could be found

### DIFF
--- a/pkg/lib/datastore.go
+++ b/pkg/lib/datastore.go
@@ -115,7 +115,7 @@ func getLatestEvent(keptnContext string, eventType string, uri string, datastore
 		var respMessage models.Error
 		message := "No Keptn " + eventType + " event found for context: " + keptnContext
 		respMessage.Message = &message
-		respMessage.Code = 400
+		respMessage.Code = 404
 		return nil, &respMessage
 	}
 


### PR DESCRIPTION
When an event could not be found, a HTTP 400 response was sent previously. This has been changed to 404