### PR TITLE
#2107 Add Git commit in CloudEvents

### DIFF
--- a/pkg/lib/v0_2_0/deployment.go
+++ b/pkg/lib/v0_2_0/deployment.go
@@ -6,13 +6,15 @@ type DeploymentTriggeredEventData struct {
 	EventData
 
 	ConfigurationChange struct {
-		GitCommit string `json:"gitCommit"`
+		Values map[string]interface{} `json:"values"`
 	} `json:"configurationChange"`
 
 	Deployment DeploymentData `json:"deployment"`
 }
 
 type DeploymentData struct {
+	// DeploymentStrategy defines the used deployment strategy
+	DeploymentStrategy string `json:"deploymentstrategy,omitempty"`
 	// DeploymentURILocal contains the local URL
 	DeploymentURIsLocal []string `json:"deploymentURIsLocal,omitempty"`
 	// DeploymentURIPublic contains the public URL

--- a/pkg/lib/v0_2_0/evaluation.go
+++ b/pkg/lib/v0_2_0/evaluation.go
@@ -45,6 +45,8 @@ type EvaluationDetails struct {
 	Score            float64                `json:"score"`
 	SLOFileContent   string                 `json:"sloFileContent"`
 	IndicatorResults []*SLIEvaluationResult `json:"indicatorResults"`
+	// GitCommit indicates the version which should be deployed
+	GitCommit string `json:"gitCommit"`
 }
 
 type SLIResult struct {

--- a/pkg/lib/v0_2_0/release.go
+++ b/pkg/lib/v0_2_0/release.go
@@ -16,4 +16,8 @@ type ReleaseStatusChangedEventData struct {
 
 type ReleaseFinishedEventData struct {
 	EventData
+	Release struct {
+		// GitCommit indicates the version which should be deployed
+		GitCommit string `json:"gitCommit"`
+	} `json:"Release"`
 }

--- a/pkg/lib/v0_2_0/test.go
+++ b/pkg/lib/v0_2_0/test.go
@@ -33,5 +33,7 @@ type TestFinishedEventData struct {
 		Start string `json:"start"`
 		// End indicates the end timestamp of the tests
 		End string `json:"end"`
+		// GitCommit indicates the version which should be deployed
+		GitCommit string `json:"gitCommit"`
 	} `json:"test"`
 }


### PR DESCRIPTION
This PR adds the Git commit hash in deployment-, test-, evaluation-, and release-finished.events.
This allows to exactly know which version was deployed, what test was performed, which SLOs have been used, and what is the released version.