### PR TITLE
#1714 Add TLS certificates handling in http client configuration

### DIFF
--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -19,11 +19,12 @@ type APIHandler struct {
 }
 
 // NewAuthenticatedAPIHandler returns a new APIHandler that authenticates at the api-service endpoint via the provided token
-func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
+func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *APIHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/authUtils.go
+++ b/pkg/api/utils/authUtils.go
@@ -27,17 +27,18 @@ func NewAuthHandler(baseURL string) *AuthHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport("", "", "")},
 		Scheme:     "http",
 	}
 }
 
 // NewAuthenticatedAuthHandler returns a new AuthHandler that authenticates at the endpoint via the provided token
-func NewAuthenticatedAuthHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *AuthHandler {
+func NewAuthenticatedAuthHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *AuthHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -23,14 +23,14 @@ type EventHandler struct {
 
 // EventFilter allows to filter events based on the provided properties
 type EventFilter struct {
-	Project      	string
-	Stage        	string
-	Service      	string
-	EventType    	string
-	KeptnContext 	string
-	EventID      	string
-	PageSize		string
-	NumberOfPages	int
+	Project       string
+	Stage         string
+	Service       string
+	EventType     string
+	KeptnContext  string
+	EventID       string
+	PageSize      string
+	NumberOfPages int
 }
 
 // NewEventHandler returns a new EventHandler
@@ -44,7 +44,7 @@ func NewEventHandler(baseURL string) *EventHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport("", "", "")},
 		Scheme:     "http",
 	}
 }
@@ -52,11 +52,12 @@ func NewEventHandler(baseURL string) *EventHandler {
 const mongodbDatastoreServiceBaseUrl = "mongodb-datastore"
 
 // NewAuthenticatedEventHandler returns a new EventHandler that authenticates at the endpoint via the provided token
-func NewAuthenticatedEventHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *EventHandler {
+func NewAuthenticatedEventHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *EventHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -32,7 +32,7 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport("", "", "")},
 		Scheme:     "http",
 	}
 }
@@ -41,11 +41,12 @@ const configurationServiceBaseUrl = "configuration-service"
 
 // NewAuthenticatedProjectHandler returns a new ProjectHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
-func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
+func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *ProjectHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -40,18 +40,19 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport("", "", "")},
 		Scheme:     "http",
 	}
 }
 
 // NewAuthenticatedResourceHandler returns a new ResourceHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
-func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ResourceHandler {
+func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *ResourceHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -32,18 +32,19 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport("", "", "")},
 		Scheme:     "http",
 	}
 }
 
 // NewAuthenticatedServiceHandler returns a new ServiceHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
-func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ServiceHandler {
+func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *ServiceHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -39,11 +39,13 @@ func NewStageHandler(baseURL string) *StageHandler {
 
 // NewAuthenticatedStageHandler returns a new StageHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
-func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
+func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string, clientCertPath, clientKeyPath, rootCertPath string) *StageHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+
+	httpClient.Transport = getClientTransport(clientCertPath, clientKeyPath, rootCertPath)
+
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 


### PR DESCRIPTION
This PR adds the mTLS configuration in the `getClientTransport()` method using the `crypto/tls` package. It requires the paths of the client certificate, client key, and the root CA certificate paths.  