### PR TITLE
Added GH actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keptn go-utils
-[![Build Status](https://travis-ci.org/keptn/go-utils.svg?branch=master)](https://travis-ci.org/keptn/go-utils)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/keptn/go-utils)
+![tests](https://github.com/keptn/go-utils/workflows/tests/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/keptn/go-utils)](https://goreportcard.com/report/github.com/keptn/go-utils)
 
 This repo serves as a util package for common functionalities such as logging of the [Keptn Project](https://github.com/keptn).


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

This PR removes the Travis-CI Badge and adds a GH action badge.

![image](https://user-images.githubusercontent.com/56065213/103202728-7dd07b80-48f3-11eb-9496-b6d4a4ee3a9a.png)
