### PR TITLE
Use json.marshal/unmarshal instead of mapstructure.Decode

### DIFF
--- a/pkg/lib/v0_2_0/events.go
+++ b/pkg/lib/v0_2_0/events.go
@@ -2,11 +2,11 @@ package v0_2_0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/keptn/go-utils/pkg/api/models"
-	"github.com/mitchellh/mapstructure"
 	"log"
 	"time"
 
@@ -106,16 +106,13 @@ func (k *Keptn) SendCloudEvent(event cloudevents.Event) error {
 }
 
 // Decode decodes the given raw interface to the target pointer specified
-// by the out paratmeter
+// by the out parameter
 func Decode(in, out interface{}) error {
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Squash: true,
-		Result: out,
-	})
+	bytes, err := json.Marshal(in)
 	if err != nil {
 		return err
 	}
-	return decoder.Decode(in)
+	return json.Unmarshal(bytes, out)
 }
 
 // EventDataAs decodes the event data of the given keptn cloud event to the

--- a/pkg/lib/v0_2_0/events_test.go
+++ b/pkg/lib/v0_2_0/events_test.go
@@ -142,7 +142,7 @@ func TestEventDataAs(t *testing.T) {
 			Message: "m",
 		},
 		ConfigurationChange: ConfigurationChange{
-			Values: map[string]interface{}{"1": 1},
+			Values: map[string]interface{}{"image": "my-image:tag"},
 		},
 		Deployment: DeploymentWithStrategy{
 			DeploymentStrategy: "direct",


### PR DESCRIPTION
`mapstructure.Decode()` didn't seem to work correctly when the structure contains a nested `map[string]interace{}` property - this is the case for e.g. the `ConfigurationChange` struct: https://github.com/keptn/go-utils/blob/b4da7753f6f2d95dfe3ebb65064d15c4564ebdee/pkg/lib/v0_2_0/configuration_change.go#L3

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>