### PR TITLE
Added remediation task name

### DIFF
--- a/pkg/lib/v0_2_0/remediation.go
+++ b/pkg/lib/v0_2_0/remediation.go
@@ -1,5 +1,7 @@
 package v0_2_0
 
+const RemediationTaskName = "remediation"
+
 // RemediationTriggeredEventData is a CloudEvent for triggering remediations
 type RemediationTriggeredEventData struct {
 	EventData


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

It looks like RemediationTaskName is missing (all other CEs seem to have a TaskName variable).

spec entry: https://github.com/keptn/spec/blob/0.2.0-alpha/cloudevents.md#remediation