### PR TITLE
split sli-targets, add key-sli

### DIFF
--- a/pkg/lib/v0_2_0/evaluation.go
+++ b/pkg/lib/v0_2_0/evaluation.go
@@ -61,10 +61,12 @@ type SLIResult struct {
 }
 
 type SLIEvaluationResult struct {
-	Score   float64      `json:"score"`
-	Value   *SLIResult   `json:"value"`
-	Targets []*SLITarget `json:"targets"`
-	Status  string       `json:"status" jsonschema:"enum=pass,enum=warning,enum=fail"`
+	Score          float64      `json:"score"`
+	Value          *SLIResult   `json:"value"`
+	PassTargets    []*SLITarget `json:"passTargets"`
+	WarningTargets []*SLITarget `json:"warningTargets"`
+	KeySLI         bool         `json:"keySli"`
+	Status         string       `json:"status" jsonschema:"enum=pass,enum=warning,enum=fail"`
 }
 
 type SLITarget struct {


### PR DESCRIPTION
Related to [#2478 SLI evaluation breakdown as barista table (#3023)](https://github.com/keptn/keptn/pull/3053)

Modified `SLIEvaluationResult`
- Split `Targets` into `PassTargets` and `WarningTargets`
- Added property `KeySLI`

Signed-off-by: Klaus Strießnig <k.striessnig@gmail.com>