### PR TITLE
#3447 Remove trimsuffix from GetKeptnResource return value

### DIFF
--- a/pkg/lib/keptn/keptn_base.go
+++ b/pkg/lib/keptn/keptn_base.go
@@ -161,8 +161,7 @@ func (k *KeptnBase) GetKeptnResource(resource string) (string, error) {
 		return "", err
 	}
 
-	// ToDo: Verify why we need TrimSuffix here
-	return strings.TrimSuffix(requestedResource.ResourceContent, "\n"), nil
+	return requestedResource.ResourceContent, nil
 }
 
 /**


### PR DESCRIPTION
Fixes another part of https://github.com/keptn/keptn/issues/3447, where we remove the trimsuffix from the return value.

The first part was already merged in PR https://github.com/keptn/go-utils/pull/267, and integration tests seem to still work.