### PR TITLE
Add function ExecuteCommandWithEnv that appends the given env to the env of the command to be executed

### DIFF
--- a/pkg/lib/cmdUtils.go
+++ b/pkg/lib/cmdUtils.go
@@ -8,7 +8,13 @@ import (
 
 // ExecuteCommand executes the command using the args
 func ExecuteCommand(command string, args []string) (string, error) {
+	return ExecuteCommandWithEnv(command, args, []string{})
+}
+
+// ExecuteCommandWithEnv executes the command using the args, appends env to the default command env
+func ExecuteCommandWithEnv(command string, args []string, env []string) (string, error) {
 	cmd := exec.Command(command, args...)
+	cmd.Env = append(cmd.Env, env...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("Error executing command %s %s: %s\n%s", command, strings.Join(args, " "), err.Error(), string(out))


### PR DESCRIPTION
This an extension needed for https://github.com/keptn-sandbox/locust-service/issues/25. Allows the locust execute command to add additional environment variables.