### PR TITLE
#4079 function for generating start and end timestamps; timeframe in evaluation.triggered data

### DIFF
--- a/pkg/common/timeutils/timeutils.go
+++ b/pkg/common/timeutils/timeutils.go
@@ -1,11 +1,93 @@
 package timeutils
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 const keptnTimeFormatISO8601 = "2006-01-02T15:04:05.000Z"
+
+const defaultEvaluationTimeframe = "5m"
 
 // GetKeptnTimeStamp formats a given timestamp into the format used by
 // Keptn which is following the ISO 8601 standard
 func GetKeptnTimeStamp(timestamp time.Time) string {
 	return timestamp.Format(keptnTimeFormatISO8601)
+}
+
+// GetStartEndTime parses the provided start date, end date and/or timeframe
+func GetStartEndTime(startDatePoint, endDatePoint, timeframe, timeFormat string) (*time.Time, *time.Time, error) {
+	if timeFormat == "" {
+		timeFormat = keptnTimeFormatISO8601
+	}
+	var err error
+	// input validation
+	if startDatePoint != "" && endDatePoint == "" {
+		// if a start date is set, but no end date is set, we require the timeframe to be set
+		if timeframe == "" {
+			errMsg := "no timeframe or end date provided"
+
+			return nil, nil, fmt.Errorf(errMsg)
+		}
+	}
+	if endDatePoint != "" && timeframe != "" {
+		// can not use end date and timeframe at the same time
+		errMsg := "You can not use 'end' together with 'timeframe'"
+
+		return nil, nil, fmt.Errorf(errMsg)
+	}
+	if endDatePoint != "" && startDatePoint == "" {
+		errMsg := "start date is required when using an end date"
+
+		return nil, nil, fmt.Errorf(errMsg)
+	}
+
+	// parse timeframe
+	var timeframeDuration time.Duration
+	if timeframe != "" {
+		timeframeDuration, err = time.ParseDuration(timeframe)
+	} else {
+		timeframeDuration, err = time.ParseDuration(defaultEvaluationTimeframe)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not parse provided timeframe: %s", err.Error())
+	}
+
+	// initialize default values for end and start time
+	end := time.Now().UTC()
+	start := time.Now().UTC().Add(-timeframeDuration)
+
+	// Parse start date
+	if startDatePoint != "" {
+		start, err = time.Parse(timeFormat, startDatePoint)
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Parse end date
+	if endDatePoint != "" {
+		end, err = time.Parse(timeFormat, endDatePoint)
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// last but not least: if a start date and a timeframe is provided, we set the end date to start date + timeframe
+	if startDatePoint != "" && endDatePoint == "" && timeframe != "" {
+		end = start.Add(timeframeDuration)
+	}
+
+	// ensure end date is greater than start date
+	diff := end.Sub(start).Minutes()
+
+	if diff < 1 {
+		errMsg := "end date must be at least 1 minute after start date"
+
+		return nil, nil, fmt.Errorf(errMsg)
+	}
+
+	return &start, &end, nil
 }

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetStartEndTime(t *testing.T) {
+	const userFriendlyTimeFormat = "2006-01-02T15:04:05"
 	tests := []struct {
 		name      string
 		args      GetStartEndTimeParams
@@ -28,10 +29,10 @@ func TestGetStartEndTime(t *testing.T) {
 		{
 			name: "start and end date provided (different time format) - return those",
 			args: GetStartEndTimeParams{
-				StartDate:  time.Now().Round(time.Minute).UTC().Format("2006-01-02T15:04:05"),
-				EndDate:    time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format("2006-01-02T15:04:05"),
+				StartDate:  time.Now().Round(time.Minute).UTC().Format(userFriendlyTimeFormat),
+				EndDate:    time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format(userFriendlyTimeFormat),
 				Timeframe:  "",
-				TimeFormat: "2006-01-02T15:04:05",
+				TimeFormat: userFriendlyTimeFormat,
 			},
 			wantStart: time.Now().Round(time.Minute).UTC(),
 			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -7,25 +7,19 @@ import (
 )
 
 func TestGetStartEndTime(t *testing.T) {
-	type args struct {
-		startDatePoint string
-		endDatePoint   string
-		timeframe      string
-		timeFormat     string
-	}
 	tests := []struct {
 		name      string
-		args      args
+		args      GetStartEndTimeParams
 		wantStart time.Time
 		wantEnd   time.Time
 		wantErr   bool
 	}{
 		{
 			name: "start and end date provided - return those",
-			args: args{
-				startDatePoint: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format(keptnTimeFormatISO8601),
-				timeframe:      "",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format(keptnTimeFormatISO8601),
+				Timeframe: "",
 			},
 			wantStart: time.Now().Round(time.Minute).UTC(),
 			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),
@@ -33,11 +27,11 @@ func TestGetStartEndTime(t *testing.T) {
 		},
 		{
 			name: "start and end date provided (different time format) - return those",
-			args: args{
-				startDatePoint: time.Now().Round(time.Minute).UTC().Format("2006-01-02T15:04:05"),
-				endDatePoint:   time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format("2006-01-02T15:04:05"),
-				timeframe:      "",
-				timeFormat:     "2006-01-02T15:04:05",
+			args: GetStartEndTimeParams{
+				StartDate:  time.Now().Round(time.Minute).UTC().Format("2006-01-02T15:04:05"),
+				EndDate:    time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format("2006-01-02T15:04:05"),
+				Timeframe:  "",
+				TimeFormat: "2006-01-02T15:04:05",
 			},
 			wantStart: time.Now().Round(time.Minute).UTC(),
 			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),
@@ -45,10 +39,10 @@ func TestGetStartEndTime(t *testing.T) {
 		},
 		{
 			name: "start and timeframe - return startdate and startdate + timeframe",
-			args: args{
-				startDatePoint: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   "",
-				timeframe:      "10m",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   "",
+				Timeframe: "10m",
 			},
 			wantStart: time.Now().Round(time.Minute).UTC(),
 			wantEnd:   time.Now().Add(10 * time.Minute).Round(time.Minute).UTC(),
@@ -56,10 +50,10 @@ func TestGetStartEndTime(t *testing.T) {
 		},
 		{
 			name: "only timeframe provided - return time.Now - timeframe and time.Now",
-			args: args{
-				startDatePoint: "",
-				endDatePoint:   "",
-				timeframe:      "10m",
+			args: GetStartEndTimeParams{
+				StartDate: "",
+				EndDate:   "",
+				Timeframe: "10m",
 			},
 			wantStart: time.Now().UTC().Add(-10 * time.Minute).Round(time.Minute).UTC(),
 			wantEnd:   time.Now().UTC().Round(time.Minute).UTC(),
@@ -67,80 +61,80 @@ func TestGetStartEndTime(t *testing.T) {
 		},
 		{
 			name: "startDate > endDate provided - return error",
-			args: args{
-				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   time.Now().UTC().Format(keptnTimeFormatISO8601),
-				timeframe:      "",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   time.Now().UTC().Format(keptnTimeFormatISO8601),
+				Timeframe: "",
 			},
 			wantErr: true,
 		},
 		{
 			name: "startDate, endDate and timeframe provided - return error",
-			args: args{
-				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   time.Now().UTC().Format(keptnTimeFormatISO8601),
-				timeframe:      "5m",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   time.Now().UTC().Format(keptnTimeFormatISO8601),
+				Timeframe: "5m",
 			},
 			wantErr: true,
 		},
 		{
 			name: "startDate provided, but no endDate or timeframe - return error",
-			args: args{
-				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   "",
-				timeframe:      "",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   "",
+				Timeframe: "",
 			},
 			wantErr: true,
 		},
 		{
 			name: "endDate provided, but no startDate or timeframe - return error",
-			args: args{
-				startDatePoint: "",
-				endDatePoint:   time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				timeframe:      "",
+			args: GetStartEndTimeParams{
+				StartDate: "",
+				EndDate:   time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				Timeframe: "",
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid timeframe string - return error",
-			args: args{
-				startDatePoint: "",
-				endDatePoint:   "",
-				timeframe:      "xyz",
+			args: GetStartEndTimeParams{
+				StartDate: "",
+				EndDate:   "",
+				Timeframe: "xyz",
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid timeframe string - return error",
-			args: args{
-				startDatePoint: "",
-				endDatePoint:   "",
-				timeframe:      "xym",
+			args: GetStartEndTimeParams{
+				StartDate: "",
+				EndDate:   "",
+				Timeframe: "xym",
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid startDate string - return error",
-			args: args{
-				startDatePoint: "abc",
-				endDatePoint:   "",
-				timeframe:      "5m",
+			args: GetStartEndTimeParams{
+				StartDate: "abc",
+				EndDate:   "",
+				Timeframe: "5m",
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid endDate string - return error",
-			args: args{
-				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
-				endDatePoint:   "abc",
-				timeframe:      "",
+			args: GetStartEndTimeParams{
+				StartDate: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				EndDate:   "abc",
+				Timeframe: "",
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotStart, gotEnd, err := GetStartEndTime(tt.args.startDatePoint, tt.args.endDatePoint, tt.args.timeframe, tt.args.timeFormat)
+			gotStart, gotEnd, err := GetStartEndTime(tt.args)
 			if tt.wantErr {
 				require.NotNil(t, err)
 				require.Nil(t, gotStart)

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestGetStartEndTime(t *testing.T) {
-	const userFriendlyTimeFormat = "2006-01-02T15:04:05"
 	tests := []struct {
 		name      string
 		args      GetStartEndTimeParams
@@ -29,10 +28,10 @@ func TestGetStartEndTime(t *testing.T) {
 		{
 			name: "start and end date provided (different time format) - return those",
 			args: GetStartEndTimeParams{
-				StartDate:  time.Now().Round(time.Minute).UTC().Format(userFriendlyTimeFormat),
-				EndDate:    time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format(userFriendlyTimeFormat),
+				StartDate:  time.Now().Round(time.Minute).UTC().Format("2006-01-02T15:04:05"),
+				EndDate:    time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format("2006-01-02T15:04:05"),
 				Timeframe:  "",
-				TimeFormat: userFriendlyTimeFormat,
+				TimeFormat: "2006-01-02T15:04:05",
 			},
 			wantStart: time.Now().Round(time.Minute).UTC(),
 			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -1,0 +1,155 @@
+package timeutils
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestGetStartEndTime(t *testing.T) {
+	type args struct {
+		startDatePoint string
+		endDatePoint   string
+		timeframe      string
+		timeFormat     string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantStart time.Time
+		wantEnd   time.Time
+		wantErr   bool
+	}{
+		{
+			name: "start and end date provided - return those",
+			args: args{
+				startDatePoint: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format(keptnTimeFormatISO8601),
+				timeframe:      "",
+			},
+			wantStart: time.Now().Round(time.Minute).UTC(),
+			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),
+			wantErr:   false,
+		},
+		{
+			name: "start and end date provided (different time format) - return those",
+			args: args{
+				startDatePoint: time.Now().Round(time.Minute).UTC().Format("2006-01-02T15:04:05"),
+				endDatePoint:   time.Now().Add(5 * time.Minute).UTC().Round(time.Minute).Format("2006-01-02T15:04:05"),
+				timeframe:      "",
+				timeFormat:     "2006-01-02T15:04:05",
+			},
+			wantStart: time.Now().Round(time.Minute).UTC(),
+			wantEnd:   time.Now().Add(5 * time.Minute).Round(time.Minute).UTC(),
+			wantErr:   false,
+		},
+		{
+			name: "start and timeframe - return startdate and startdate + timeframe",
+			args: args{
+				startDatePoint: time.Now().Round(time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   "",
+				timeframe:      "10m",
+			},
+			wantStart: time.Now().Round(time.Minute).UTC(),
+			wantEnd:   time.Now().Add(10 * time.Minute).Round(time.Minute).UTC(),
+			wantErr:   false,
+		},
+		{
+			name: "only timeframe provided - return time.Now - timeframe and time.Now",
+			args: args{
+				startDatePoint: "",
+				endDatePoint:   "",
+				timeframe:      "10m",
+			},
+			wantStart: time.Now().UTC().Add(-10 * time.Minute).Round(time.Minute).UTC(),
+			wantEnd:   time.Now().UTC().Round(time.Minute).UTC(),
+			wantErr:   false,
+		},
+		{
+			name: "startDate > endDate provided - return error",
+			args: args{
+				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   time.Now().UTC().Format(keptnTimeFormatISO8601),
+				timeframe:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "startDate, endDate and timeframe provided - return error",
+			args: args{
+				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   time.Now().UTC().Format(keptnTimeFormatISO8601),
+				timeframe:      "5m",
+			},
+			wantErr: true,
+		},
+		{
+			name: "startDate provided, but no endDate or timeframe - return error",
+			args: args{
+				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   "",
+				timeframe:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "endDate provided, but no startDate or timeframe - return error",
+			args: args{
+				startDatePoint: "",
+				endDatePoint:   time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				timeframe:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid timeframe string - return error",
+			args: args{
+				startDatePoint: "",
+				endDatePoint:   "",
+				timeframe:      "xyz",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid timeframe string - return error",
+			args: args{
+				startDatePoint: "",
+				endDatePoint:   "",
+				timeframe:      "xym",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid startDate string - return error",
+			args: args{
+				startDatePoint: "abc",
+				endDatePoint:   "",
+				timeframe:      "5m",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid endDate string - return error",
+			args: args{
+				startDatePoint: time.Now().Add(1 * time.Minute).UTC().Format(keptnTimeFormatISO8601),
+				endDatePoint:   "abc",
+				timeframe:      "",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStart, gotEnd, err := GetStartEndTime(tt.args.startDatePoint, tt.args.endDatePoint, tt.args.timeframe, tt.args.timeFormat)
+			if tt.wantErr {
+				require.NotNil(t, err)
+				require.Nil(t, gotStart)
+				require.Nil(t, gotEnd)
+			} else {
+				require.Nil(t, err)
+				require.WithinDuration(t, *gotStart, tt.wantStart, time.Minute)
+				require.WithinDuration(t, *gotEnd, tt.wantEnd, time.Minute)
+			}
+		})
+	}
+}

--- a/pkg/lib/v0_2_0/evaluation.go
+++ b/pkg/lib/v0_2_0/evaluation.go
@@ -21,6 +21,8 @@ type Evaluation struct {
 	Start string `json:"start"`
 	// End indicates the end timestamp of the tests
 	End string `json:"end"`
+	// Timeframe indicates the timeframe of the evaluation
+	Timeframe string `json:"timeframe"`
 }
 
 type Deployment struct {


### PR DESCRIPTION
Needed for https://github.com/keptn/keptn/issues/4079

Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>