### PR TITLE
Common Utils: Added retry package

### DIFF
--- a/pkg/common/retry/retry.go
+++ b/pkg/common/retry/retry.go
@@ -1,0 +1,68 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultNumberOfRetries     = 20
+	DefaultDelayBetweenRetires = time.Second * 5
+)
+
+type Option func(*RetryConfiguration)
+
+func NumberOfRetries(n uint) Option {
+	return func(c *RetryConfiguration) {
+		c.numberOfRetries = n
+	}
+}
+
+func DelayBetweenRetries(d time.Duration) Option {
+	return func(c *RetryConfiguration) {
+		c.delayBetweenRetries = d
+	}
+}
+
+func Context(ctx context.Context) Option {
+	return func(c *RetryConfiguration) {
+		c.context = ctx
+	}
+}
+
+type RetryConfiguration struct {
+	context             context.Context
+	numberOfRetries     uint
+	delayBetweenRetries time.Duration
+}
+
+type RetryFunc func() error
+
+// Retry executes the retryFunc repeatedly until it was successful or canceled by the context
+// The default number of retries is 20 and the default delay between retries is 5 seconds
+func Retry(retryFunc RetryFunc, opts ...Option) error {
+	configuration := &RetryConfiguration{
+		numberOfRetries:     DefaultNumberOfRetries,
+		delayBetweenRetries: DefaultDelayBetweenRetires,
+		context:             context.TODO()}
+	for _, opt := range opts {
+		opt(configuration)
+	}
+
+	var i uint
+	for i < configuration.numberOfRetries {
+		err := retryFunc()
+		if err != nil {
+			select {
+			case <-time.After(configuration.delayBetweenRetries):
+			case <-configuration.context.Done():
+				return fmt.Errorf("retry cancelled")
+			}
+		} else {
+			return nil
+		}
+		i++
+	}
+	return fmt.Errorf("operation unsuccessful after %d retry", i)
+}

--- a/pkg/common/retry/retry_test.go
+++ b/pkg/common/retry/retry_test.go
@@ -1,0 +1,87 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/keptn/go-utils/pkg/common/retry"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDefaultNumberOfRetriesAllFail(t *testing.T) {
+	var count int
+	err := retry.Retry(
+		func() error {
+			count++
+			fmt.Println(count)
+			return errors.New("test")
+		},
+		retry.DelayBetweenRetries(time.Millisecond*10),
+	)
+	assert.Equal(t, retry.DefaultNumberOfRetries, count)
+	assert.NotNil(t, err)
+}
+
+func TestDefaultLastRetrySucceeded(t *testing.T) {
+	var count int
+	err := retry.Retry(
+		func() error {
+			count++
+			if count == retry.DefaultNumberOfRetries {
+				return nil
+			}
+			return errors.New("test")
+		},
+		retry.DelayBetweenRetries(time.Millisecond*10),
+	)
+	assert.Equal(t, retry.DefaultNumberOfRetries, count)
+	assert.Nil(t, err)
+}
+
+func TestCustomNumberOfRetriesAllFail(t *testing.T) {
+	var count int
+	err := retry.Retry(
+		func() error {
+			count++
+			fmt.Println(count)
+			return errors.New("test")
+		},
+		retry.DelayBetweenRetries(time.Millisecond*1),
+		retry.NumberOfRetries(50),
+	)
+	assert.Equal(t, 50, count)
+	assert.NotNil(t, err)
+}
+
+func TestFirstCallSucceeded(t *testing.T) {
+	var count int
+	err := retry.Retry(
+		func() error {
+			count++
+			return nil
+		},
+		retry.DelayBetweenRetries(time.Millisecond*10),
+	)
+	assert.Equal(t, 1, count)
+	assert.Nil(t, err)
+}
+
+func TestCancelRetries(t *testing.T) {
+	var count int
+	ctx, cancel := context.WithCancel(context.TODO())
+	err := retry.Retry(
+		func() error {
+			count++
+			if count > 10 {
+				cancel()
+			}
+			return errors.New("test")
+		},
+		retry.DelayBetweenRetries(time.Millisecond*10),
+		retry.Context(ctx),
+	)
+	assert.Equal(t, 11, count)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This PR adds a `retry` package to common utils usable for executing actions repeatedly until the succeed. (e.g. retry http request,...)

Signed-off-by: warber <bernd.warmuth@dynatrace.com>