### PR TITLE
 Always set shkeptnspecversion when sending a cloudevent

### DIFF
--- a/pkg/lib/v0_2_0/events.go
+++ b/pkg/lib/v0_2_0/events.go
@@ -74,18 +74,61 @@ func (httpSender HTTPEventSender) SendEvent(event cloudevents.Event) error {
 	for i := 0; i <= MAX_SEND_RETRIES; i++ {
 		result = httpSender.Client.Send(ctx, event)
 		httpResult, ok := result.(*httpprotocol.Result)
-		if ok {
+		switch {
+		case ok:
 			if httpResult.StatusCode >= 200 && httpResult.StatusCode < 300 {
 				return nil
 			}
 			<-time.After(keptn.GetExpBackoffTime(i + 1))
-		} else if cloudevents.IsUndelivered(result) {
+		case cloudevents.IsUndelivered(result):
 			<-time.After(keptn.GetExpBackoffTime(i + 1))
-		} else {
+		default:
 			return nil
 		}
 	}
 	return errors.New("Failed to send cloudevent: " + result.Error())
+}
+
+// EventSender fakes the sending of CloudEvents
+type TestSender struct {
+	SentEvents []cloudevents.Event
+	Reactors   map[string]func(event cloudevents.Event) error
+}
+
+// SendEvent fakes the sending of CloudEvents
+func (s *TestSender) SendEvent(event cloudevents.Event) error {
+	if s.Reactors != nil {
+		for eventTypeSelector, reactor := range s.Reactors {
+			if eventTypeSelector == "*" || eventTypeSelector == event.Type() {
+				if err := reactor(event); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	s.SentEvents = append(s.SentEvents, event)
+	return nil
+}
+
+// AssertSentEventTypes checks if the given event types have been passed to the SendEvent function
+func (s *TestSender) AssertSentEventTypes(eventTypes []string) error {
+	if len(s.SentEvents) != len(eventTypes) {
+		return fmt.Errorf("expected %d event, got %d", len(s.SentEvents), len(eventTypes))
+	}
+	for index, event := range s.SentEvents {
+		if event.Type() != eventTypes[index] {
+			return fmt.Errorf("received event type '%s' != %s", event.Type(), eventTypes[index])
+		}
+	}
+	return nil
+}
+
+// AddReactor adds custom logic that should be applied when SendEvent is called for the given event type
+func (s *TestSender) AddReactor(eventTypeSelector string, reactor func(event cloudevents.Event) error) {
+	if s.Reactors == nil {
+		s.Reactors = map[string]func(event cloudevents.Event) error{}
+	}
+	s.Reactors[eventTypeSelector] = reactor
 }
 
 // GetTriggeredEventType returns for the given task the name of the triggered event type
@@ -291,7 +334,6 @@ type KeptnEventBuilder struct {
 // Build creates a value of KeptnContextExtendedCE from the current builder
 // It also does basic validation like the presence of project, service and stage in the event data
 func (eb *KeptnEventBuilder) Build() (models.KeptnContextExtendedCE, error) {
-
 	commonEventData := EventData{}
 	if err := eb.DataAs(&commonEventData); err != nil {
 		return eb.KeptnContextExtendedCE, err
@@ -344,7 +386,6 @@ func ToCloudEvent(keptnEvent models.KeptnContextExtendedCE) cloudevents.Event {
 
 // ToKeptnEvent takes a CloudEvent and converts it into a KeptnContextExtendedCE
 func ToKeptnEvent(event cloudevents.Event) (models.KeptnContextExtendedCE, error) {
-
 	var keptnContext string
 	event.ExtensionAs(keptnContextCEExtension, &keptnContext)
 

--- a/pkg/lib/v0_2_0/keptn.go
+++ b/pkg/lib/v0_2_0/keptn.go
@@ -90,6 +90,7 @@ func (k *Keptn) GetShipyard() (*Shipyard, error) {
 
 // SendCloudEvent sends a cloudevent to the event broker
 func (k *Keptn) SendCloudEvent(event cloudevents.Event) error {
+	event.SetExtension(keptnSpecVersionCEExtension, defaultKeptnSpecVersion)
 	if k.UseLocalFileSystem {
 		log.Println(fmt.Printf("%v", string(event.Data())))
 		return nil


### PR DESCRIPTION
fixes https://github.com/keptn/keptn/issues/3408

I've also added the `TestSender` implementation to go-utils

Signed-off-by: warber <bernd.warmuth@dynatrace.com>