### PR TITLE
Added EventSender context

### DIFF
--- a/pkg/lib/keptn/keptn_base.go
+++ b/pkg/lib/keptn/keptn_base.go
@@ -1,6 +1,7 @@
 package keptn
 
 import (
+	"context"
 	"fmt"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"log"
@@ -59,9 +60,13 @@ type EventProperties interface {
 	SetLabels(map[string]string)
 }
 
-// EventSender describes the interface for sending a CloudEvent
 type EventSender interface {
+	// SendEvent sends a cloud event
+	// Deprecated: use EventSender.Send instead
 	SendEvent(event cloudevents.Event) error
+
+	// Send sends a cloud event
+	Send(ctx context.Context, event cloudevents.Event) error
 }
 
 // SLIConfig represents the struct of a SLI file

--- a/pkg/lib/v0_2_0/events.go
+++ b/pkg/lib/v0_2_0/events.go
@@ -69,7 +69,10 @@ func NewHTTPEventSender(endpoint string) (*HTTPEventSender, error) {
 func (httpSender HTTPEventSender) SendEvent(event cloudevents.Event) error {
 	ctx := cloudevents.ContextWithTarget(context.Background(), httpSender.EventsEndpoint)
 	ctx = cloudevents.WithEncodingStructured(ctx)
+	return httpSender.Send(ctx, event)
+}
 
+func (httpSender HTTPEventSender) Send(ctx context.Context, event cloudevents.Event) error {
 	var result protocol.Result
 	for i := 0; i <= MAX_SEND_RETRIES; i++ {
 		result = httpSender.Client.Send(ctx, event)
@@ -97,6 +100,10 @@ type TestSender struct {
 
 // SendEvent fakes the sending of CloudEvents
 func (s *TestSender) SendEvent(event cloudevents.Event) error {
+	return s.Send(context.TODO(), event)
+}
+
+func (s *TestSender) Send(ctx context.Context, event cloudevents.Event) error {
 	if s.Reactors != nil {
 		for eventTypeSelector, reactor := range s.Reactors {
 			if eventTypeSelector == "*" || eventTypeSelector == event.Type() {

--- a/pkg/lib/v0_2_0/fake/events.go
+++ b/pkg/lib/v0_2_0/fake/events.go
@@ -1,6 +1,7 @@
 package fake
 
 import (
+	"context"
 	"fmt"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
@@ -13,6 +14,10 @@ type EventSender struct {
 
 // SendEvent fakes the sending of CloudEvents
 func (es *EventSender) SendEvent(event cloudevents.Event) error {
+	return es.Send(context.TODO(), event)
+}
+
+func (es *EventSender) Send(ctx context.Context, event cloudevents.Event) error {
 	if es.Reactors != nil {
 		for eventTypeSelector, reactor := range es.Reactors {
 			if eventTypeSelector == "*" || eventTypeSelector == event.Type() {


### PR DESCRIPTION
This PR adds a go context to the EventSender interface Method as an agument, to control the behavior of the send event logic.

Signed-off-by: warber <bernd.warmuth@dynatrace.com>