### PR TITLE
ci: Add pre-release pipeline that can be triggered manually (#4762)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,13 +2,13 @@
 <!-- Please use the sections that you need and delete other sections -->
 
 ## This PR
-
-- adds this new feature
 <!-- add the description of the PR here -->
 
-### Related Issues
+- adds this new feature
 
+### Related Issues
 <!-- add here the GitHub issue that this PR resolves if applicable -->
+
 Fixes #1234523
 
 ### Notes

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -55,17 +55,17 @@ jobs:
         run: |
           npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
 
-      - name: Enhance Release Notes
+      - name: Enhance Release Notes with Build Metadata
         run: |
           echo "#### Build Information\n\n" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
-      - name: Create release package
+      - name: Create pre-release package
         id: create-release-package
         env:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         run: |
-          echo "🚀 Creating release package now..."
+          echo "🚀 Creating pre-release package now..."
           npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}"
 
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,79 @@
+name: Pre-Release
+on:
+  workflow_dispatch:
+env:
+  NODE_VERSION: 14
+  KEPTN_BOT_NAME: "Keptn Bot"
+  KEPTN_BOT_EMAIL: "keptn-bot <86361500+keptn-bot@users.noreply.github.com>"
+  RELEASE_NOTES_FILE: "RELEASE-BODY.md"
+  PRERELEASE_KEYWORD: "next"
+defaults:
+  run:
+    shell: bash
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    env:
+      GO111MODULE: "on"
+      GOPROXY: "https://proxy.golang.org"
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+      - name: Test
+        run: go test -race -v ./...
+  release:
+    runs-on: ubuntu-20.04
+    needs: [test]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Configure Git
+        env:
+          KEPTN_BOT_NAME: ${{ env.KEPTN_BOT_NAME }}
+          KEPTN_BOT_EMAIL: ${{ env.KEPTN_BOT_EMAIL }}
+        run: |
+          git config user.name "$KEPTN_BOT_NAME"
+          git config user.email "$KEPTN_BOT_EMAIL"
+
+      - name: Prepare GitHub Release Notes
+        run: |
+          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
+
+      - name: Enhance Release Notes
+        run: |
+          echo "#### Build Information\n\n" >> "${{ env.RELEASE_NOTES_FILE }}"
+          echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
+
+      - name: Create release package
+        id: create-release-package
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+        run: |
+          echo "🚀 Creating release package now..."
+          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}"
+
+          echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+          echo "⚡️ Pushing changes to remote repository..."
+          git push --follow-tags
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+        run: |
+          gh release create "${{ steps.create-release-package.outputs.tag-name }}" --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/checkout@v2.3.4
       - name: Test
         run: go test -race -v ./...
-  release:
+  pre-release:
+    name: Pre-Release
     runs-on: ubuntu-20.04
     needs: [test]
     steps:
@@ -57,7 +58,8 @@ jobs:
 
       - name: Enhance Release Notes with Build Metadata
         run: |
-          echo "#### Build Information\n\n" >> "${{ env.RELEASE_NOTES_FILE }}"
+          echo "#### Build Information" >> "${{ env.RELEASE_NOTES_FILE }}"
+          echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
       - name: Create pre-release package
@@ -66,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         run: |
           echo "🚀 Creating pre-release package now..."
-          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}"
+          npx standard-version@^9.3.1 --prerelease "${{ env.PRERELEASE_KEYWORD }}" --skip.commit --skip.changelog
 
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
           echo "⚡️ Pushing changes to remote repository..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Test
         run: go test -race -v ./...
   release:
+    name: "Release"
     runs-on: ubuntu-20.04
     needs: [test]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,4 +70,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
         run: |
-          gh release create "${{ steps.create-release-package.outputs.tag-name }}" --notes-file "${{ env.RELEASE_NOTES_FILE }}"
+          gh release create "${{ steps.create-release-package.outputs.tag-name }}" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}"


### PR DESCRIPTION
## This PR

- adds a new pipeline to create **prereleases**
- creates pre-releases with version numbers according to the following naming scheme:
  - if new version would be `0.9.0`, the pre-release version will be `0.9.0-next.N` with increasing numbers for `N` with every new pre-release until a new actual release is created
- switches the **release** pipeline to create draft releases instead of public releases. The pipeline will still create a release commit and and a tag though ⚠️

### Related Issues

Fixes keptn/keptn#4762

