### PR TITLE
build: Update dependabot config to adhere to new commit message scheme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    commit-message:
+      include: scope
+      prefix: build
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    commit-message:
+      include: scope
+      prefix: build


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Updates the dependabot config to follow the new commit message scheme

