### PR TITLE
fix: http clients should support standard proxy settings

### DIFF
--- a/pkg/api/utils/apiServiceUtils.go
+++ b/pkg/api/utils/apiServiceUtils.go
@@ -22,6 +22,7 @@ type APIService interface {
 func getClientTransport() *http.Transport {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	return tr
 }


### PR DESCRIPTION
Signed-off-by: Arthur Pitman <arthur.pitman@dynatrace.com>

## This PR
- ensures that `http.Client` instances respect the standard go HTTP proxy settings even when using a custom `http.Transport` by adding `Proxy: http.ProxyFromEnvironment` to the `Transport`

### Notes
While probably not an issue in most places, it caused some inconsistent behavior in the dynatrace-service.
Might be useful for adding proxy support for other components using go-utils.
