### PR TITLE
ci: fix branch protection during releases, add release title

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -62,6 +62,13 @@ jobs:
           echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: false
+
       - name: Create pre-release package
         id: create-release-package
         env:
@@ -74,8 +81,17 @@ jobs:
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
 
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: true
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          gh release create "${{ steps.create-release-package.outputs.tag-name }}" --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}"
+          gh release create "$RELEASE_TAG" --prerelease --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
       - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.7
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
           branch: ${{ github.event.repository.default_branch }}
@@ -82,8 +82,8 @@ jobs:
           git push --follow-tags
 
       - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
           branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,13 @@ jobs:
         run: |
           npx standard-version@^9.3.1 -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
 
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: false
+
       - name: Create release package
         id: create-release-package
         env:
@@ -67,8 +74,17 @@ jobs:
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
 
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: true
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.KEPTN_BOT_TOKEN }}
+          RELEASE_TAG: ${{ steps.create-release-package.outputs.tag-name }}
         run: |
-          gh release create "${{ steps.create-release-package.outputs.tag-name }}" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}"
+          gh release create "$RELEASE_TAG" --draft --notes-file "${{ env.RELEASE_NOTES_FILE }}" --title "$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           npx standard-version@^9.3.1 -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
 
       - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.7
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
           branch: ${{ github.event.repository.default_branch }}
@@ -75,8 +75,8 @@ jobs:
           git push --follow-tags
 
       - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
         with:
           access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
           branch: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fixes the auto-release workflow which had issue with branch protection rules during the automatic push of the release commit
- adds a title to the GitHub Release which is the same as the tag name

