### PR TITLE
ci: Fix issue where release changelog would not contain changes that were in an earlier pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -62,13 +62,6 @@ jobs:
           echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
-      - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
-          enforce_admins: false
-
       - name: Create pre-release package
         id: create-release-package
         env:
@@ -80,14 +73,6 @@ jobs:
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
-
-      - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
-        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
-          enforce_admins: true
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
 
       - name: Prepare GitHub Release Notes
         run: |
+          # Delete pre-release tags to be able to generate a changelog from last 'real' release
+          # This is a workaround for a known limitation of standard-version
+          # Reference: https://github.com/conventional-changelog/standard-version/issues/203#issuecomment-872415140
+          git tag -l | grep -vE '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | xargs git tag -d
+
           npx standard-version@^9.3.1 -i "${{ env.RELEASE_NOTES_FILE }}" --skip.commit --skip.tag --header ""
 
       - name: Temporarily disable "include administrators" branch protection
@@ -71,6 +76,9 @@ jobs:
           npx standard-version@^9.3.1
 
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
+
+          echo "Fetching previously deleted old tags..."
+          git fetch origin --tags -f
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
 


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- fixes a bug in the release pipeline that led to the behaviour that changes from a pre-release were not picked up again for a following full release (in the changelog)
- removes unnecessary use of the `branch-protection-bot`
