### PR TITLE
feat: Add new keptn version with context propagation in place

### DIFF
--- a/pkg/lib/v0_2_0/events.go
+++ b/pkg/lib/v0_2_0/events.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/cloudevents/sdk-go/v2/protocol"
 	"github.com/google/uuid"
 	"github.com/keptn/go-utils/config"
 	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/keptn/go-utils/pkg/common/strutils"
 	"github.com/keptn/go-utils/pkg/lib/keptn"
-	"strings"
-	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	httpprotocol "github.com/cloudevents/sdk-go/v2/protocol/http"
@@ -65,7 +66,7 @@ func NewHTTPEventSender(endpoint string) (*HTTPEventSender, error) {
 	return httpSender, nil
 }
 
-// SendEvent sends a CloudEvent
+// Deprecated: use HTTPEventSender.Send instead
 func (httpSender HTTPEventSender) SendEvent(event cloudevents.Event) error {
 	ctx := cloudevents.ContextWithTarget(context.Background(), httpSender.EventsEndpoint)
 	ctx = cloudevents.WithEncodingStructured(ctx)
@@ -73,6 +74,17 @@ func (httpSender HTTPEventSender) SendEvent(event cloudevents.Event) error {
 }
 
 func (httpSender HTTPEventSender) Send(ctx context.Context, event cloudevents.Event) error {
+
+	// if not already added by the caller, add the one from the Sender
+	if cloudevents.TargetFromContext(ctx) == nil {
+		ctx = cloudevents.ContextWithTarget(ctx, httpSender.EventsEndpoint)
+	}
+
+	// TODO: Should we also add cloudevents.WithEncodingStructured(ctx) here to avoid duplication?
+	// There doesn't seem to be a way to check if already present in the ctx, as the key
+	// is not exported: https://github.com/cloudevents/sdk-go/blob/main/v2/binding/write.go#L19
+	// unles we copy the key to our code - which could be problematic if cloudevents change it later.
+
 	var result protocol.Result
 	for i := 0; i <= MAX_SEND_RETRIES; i++ {
 		result = httpSender.Client.Send(ctx, event)

--- a/pkg/lib/v0_3_0/keptn.go
+++ b/pkg/lib/v0_3_0/keptn.go
@@ -1,0 +1,226 @@
+package v0_3_0
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+
+	"github.com/keptn/go-utils/config"
+	api "github.com/keptn/go-utils/pkg/api/utils"
+	"github.com/keptn/go-utils/pkg/lib/keptn"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+)
+
+const keptnStartedEventSuffix = ".started"
+const keptnStatusChangedEventSuffix = ".status.changed"
+const keptnFinishedEventSuffix = ".finished"
+
+const keptnContextCEExtension = "shkeptncontext"
+const keptnSpecVersionCEExtension = "shkeptnspecversion"
+const triggeredIDCEExtension = "triggeredid"
+
+type Keptn struct {
+	keptn.KeptnBase
+}
+
+func NewKeptn(incomingEvent *cloudevents.Event, opts keptn.KeptnOpts) (*Keptn, error) {
+	extension, _ := incomingEvent.Context.GetExtension("shkeptncontext")
+	shkeptncontext := extension.(string)
+
+	// create a base KeptnBase Event
+	keptnBase := &keptnv2.EventData{}
+
+	if err := incomingEvent.DataAs(keptnBase); err != nil {
+		return nil, err
+	}
+
+	k := &Keptn{
+		KeptnBase: keptn.KeptnBase{
+			Event:              keptnBase,
+			CloudEvent:         incomingEvent,
+			KeptnContext:       shkeptncontext,
+			UseLocalFileSystem: opts.UseLocalFileSystem,
+			ResourceHandler:    nil,
+		}}
+
+	csURL := keptn.ConfigurationServiceURL
+	if opts.ConfigurationServiceURL != "" {
+		csURL = opts.ConfigurationServiceURL
+	}
+
+	if opts.EventBrokerURL != "" && opts.EventSender == nil {
+		httpSender, err := keptnv2.NewHTTPEventSender(opts.EventBrokerURL)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize Keptn Handler: %s", err.Error())
+		}
+		k.KeptnBase.EventSender = httpSender
+	} else if opts.EventSender != nil {
+		k.KeptnBase.EventSender = opts.EventSender
+	} else {
+		httpSender, err := keptnv2.NewHTTPEventSender(keptnv2.DefaultHTTPEventEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize Keptn Handler: %s", err.Error())
+		}
+		k.KeptnBase.EventSender = httpSender
+	}
+
+	datastoreURL := keptn.DatastoreURL
+	if opts.DatastoreURL != "" {
+		datastoreURL = opts.DatastoreURL
+	}
+
+	k.ResourceHandler = api.NewResourceHandler(csURL)
+	k.EventHandler = api.NewEventHandler(datastoreURL)
+
+	loggingServiceName := keptn.DefaultLoggingServiceName
+	if opts.LoggingOptions != nil && opts.LoggingOptions.ServiceName != nil {
+		loggingServiceName = *opts.LoggingOptions.ServiceName
+	}
+	k.Logger = keptn.NewLogger(k.KeptnContext, incomingEvent.Context.GetID(), loggingServiceName)
+
+	return k, nil
+}
+
+// GetShipyard returns the shipyard definition of a project
+func (k *Keptn) GetShipyard() (*keptnv2.Shipyard, error) {
+	shipyardResource, err := k.ResourceHandler.GetProjectResource(k.Event.GetProject(), "shipyard.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	shipyard := keptnv2.Shipyard{}
+	err = yaml.Unmarshal([]byte(shipyardResource.ResourceContent), &shipyard)
+	if err != nil {
+		return nil, err
+	}
+	return &shipyard, nil
+}
+
+// SendCloudEvent sends a cloudevent to the event broker
+func (k *Keptn) SendCloudEvent(ctx context.Context, event cloudevents.Event) error {
+	event.SetExtension(keptnSpecVersionCEExtension, config.GetKeptnGoUtilsConfig().ShKeptnSpecVersion)
+	if k.UseLocalFileSystem {
+		log.Println(fmt.Printf("%v", string(event.Data())))
+		return nil
+	}
+
+	ctx = cloudevents.WithEncodingStructured(ctx)
+	return k.EventSender.Send(ctx, event)
+}
+
+// SendTaskStartedEvent sends a .started event for the incoming .triggered event the KeptnHandler was initialized with.
+// It returns the ID of the sent CloudEvent or an error
+func (k *Keptn) SendTaskStartedEvent(ctx context.Context, data keptn.EventProperties, source string) (string, error) {
+	if k.CloudEvent == nil {
+		return "", fmt.Errorf("no incoming .triggered CloudEvent provided to the Keptn Handler")
+	}
+	outEventType, err := keptnv2.GetEventTypeForTriggeredEvent(k.CloudEvent.Type(), keptnStartedEventSuffix)
+	if err != nil {
+		return "", fmt.Errorf("could not determine .started event type for base event: %s", err.Error())
+	}
+
+	return k.sendEventWithBaseEventContext(ctx, data, source, err, outEventType)
+}
+
+// SendTaskStartedEvent sends a .status.changed event for the incoming .triggered event the KeptnHandler was initialized with.
+// It returns the ID of the sent CloudEvent or an error
+func (k *Keptn) SendTaskStatusChangedEvent(ctx context.Context, data keptn.EventProperties, source string) (string, error) {
+	if k.CloudEvent == nil {
+		return "", fmt.Errorf("no incoming .triggered CloudEvent provided to the Keptn Handler")
+	}
+	outEventType, err := keptnv2.GetEventTypeForTriggeredEvent(k.CloudEvent.Type(), keptnStatusChangedEventSuffix)
+	if err != nil {
+		return "", fmt.Errorf("could not determine .status.changed event type for base event: %s", err.Error())
+	}
+
+	return k.sendEventWithBaseEventContext(ctx, data, source, err, outEventType)
+}
+
+// SendTaskStartedEvent sends a .finished event for the incoming .triggered event the KeptnHandler was initialized with.
+// It returns the ID of the sent CloudEvent or an error
+func (k *Keptn) SendTaskFinishedEvent(ctx context.Context, data keptn.EventProperties, source string) (string, error) {
+	if k.CloudEvent == nil {
+		return "", fmt.Errorf("no incoming .triggered CloudEvent provided to the Keptn Handler")
+	}
+	outEventType, err := keptnv2.GetEventTypeForTriggeredEvent(k.CloudEvent.Type(), keptnFinishedEventSuffix)
+	if err != nil {
+		return "", fmt.Errorf("could not determine .finished event type for base event: %s", err.Error())
+	}
+
+	return k.sendEventWithBaseEventContext(ctx, data, source, err, outEventType)
+}
+
+func (k *Keptn) sendEventWithBaseEventContext(ctx context.Context, data keptn.EventProperties, source string, err error, outEventType string) (string, error) {
+	if source == "" {
+		return "", errors.New("must provide non-empty source")
+	}
+	keptnContext, err := k.CloudEvent.Context.GetExtension(keptnContextCEExtension)
+	if err != nil {
+		return "", fmt.Errorf("could not determine shkeptncontext of base event: %s", err.Error())
+	}
+
+	ce, err := k.createCloudEventWithContextAndPayload(outEventType, keptnContext, source, data)
+	if err != nil {
+		return "", fmt.Errorf("could not initialize CloudEvent: %s", err.Error())
+	}
+
+	ctx = cloudevents.WithEncodingStructured(ctx)
+	if err := k.EventSender.Send(ctx, *ce); err != nil {
+		return "", fmt.Errorf("could not send CloudEvent: %s", err.Error())
+	}
+	return ce.ID(), nil
+}
+
+// createCloudEventWithContextAndPayload initializes a new CloudEvent and ensures that context attributes such as the triggeredID, keptnContext,
+// as well as project, stage, service and labels are included in the resulting event
+func (k *Keptn) createCloudEventWithContextAndPayload(outEventType string, keptnContext interface{}, source string, data keptn.EventProperties) (*cloudevents.Event, error) {
+	ce := cloudevents.NewEvent()
+	ce.SetID(uuid.New().String())
+	ce.SetType(outEventType)
+	ce.SetDataContentType(cloudevents.ApplicationJSON)
+	// use existing  keptnContext for the new cloudevent
+	ce.SetExtension(keptnContextCEExtension, keptnContext)
+	// the triggeredID links the sent event to the received .triggered event
+	ce.SetExtension(triggeredIDCEExtension, k.CloudEvent.ID())
+	ce.SetSource(source)
+
+	// if available, add the keptnspecversion extension to the CloudEvent context
+	if keptnSpecVersion, err := k.CloudEvent.Context.GetExtension(keptnSpecVersionCEExtension); err == nil && keptnSpecVersion != "" {
+		ce.SetExtension(keptnSpecVersionCEExtension, keptnSpecVersion)
+	}
+
+	var eventData keptn.EventProperties
+	if data != nil {
+		eventData = data
+	} else {
+		eventData = &keptnv2.EventData{}
+	}
+
+	eventData = ensureContextAttributesAreSet(k.Event, eventData)
+	if err := ce.SetData(cloudevents.ApplicationJSON, eventData); err != nil {
+		return nil, fmt.Errorf("could not set data of CloudEvent: %s", err.Error())
+	}
+	return &ce, nil
+}
+
+// ensureContextAttributesAreSet makes sure all properties that remain constant over the course of a task sequence execution are set in the outgoing event
+func ensureContextAttributesAreSet(srcEvent, newEvent keptn.EventProperties) keptn.EventProperties {
+	newEvent.SetProject(srcEvent.GetProject())
+	newEvent.SetStage(srcEvent.GetStage())
+	newEvent.SetService(srcEvent.GetService())
+	labels := srcEvent.GetLabels()
+
+	// make sure labels from triggered event are included. Existing labels cannot be changed, but new ones can be added
+	for key, value := range newEvent.GetLabels() {
+		if labels[key] == "" {
+			labels[key] = value
+		}
+	}
+	newEvent.SetLabels(labels)
+	return newEvent
+}

--- a/pkg/lib/v0_3_0/keptn_test.go
+++ b/pkg/lib/v0_3_0/keptn_test.go
@@ -1,0 +1,376 @@
+package v0_3_0
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/keptn/go-utils/pkg/lib/keptn"
+	keptnv2 "github.com/keptn/go-utils/pkg/lib/v0_2_0"
+	"github.com/keptn/go-utils/pkg/lib/v0_2_0/fake"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ensureContextAttributesAreSet(t *testing.T) {
+	type args struct {
+		srcEvent keptn.EventProperties
+		newEvent keptn.EventProperties
+	}
+	tests := []struct {
+		name string
+		args args
+		want keptn.EventProperties
+	}{
+		{
+			name: "copy context attributes to empty event",
+			args: args{
+				srcEvent: &keptnv2.EventData{
+					Project: "my-project",
+					Stage:   "my-stage",
+					Service: "my-service",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				newEvent: &keptnv2.EventData{},
+			},
+			want: &keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+		{
+			name: "add new labels to event",
+			args: args{
+				srcEvent: &keptnv2.EventData{
+					Project: "my-project",
+					Stage:   "my-stage",
+					Service: "my-service",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				newEvent: &keptnv2.EventData{
+					Project: "my-project",
+					Stage:   "my-stage",
+					Service: "my-service",
+					Labels: map[string]string{
+						"bar": "foo",
+					},
+				},
+			},
+			want: &keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+				Labels: map[string]string{
+					"foo": "bar",
+					"bar": "foo",
+				},
+			},
+		},
+		{
+			name: "merge labels - do not overwrite existing ones",
+			args: args{
+				srcEvent: &keptnv2.EventData{
+					Project: "my-project",
+					Stage:   "my-stage",
+					Service: "my-service",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				newEvent: &keptnv2.EventData{
+					Project: "my-project",
+					Stage:   "my-stage",
+					Service: "my-service",
+					Labels: map[string]string{
+						"foo": "foo",
+						"bar": "foo",
+					},
+				},
+			},
+			want: &keptnv2.EventData{
+				Project: "my-project",
+				Stage:   "my-stage",
+				Service: "my-service",
+				Labels: map[string]string{
+					"foo": "bar",
+					"bar": "foo",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureContextAttributesAreSet(tt.args.srcEvent, tt.args.newEvent)
+
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestKeptn_SendEventConvenienceFunctions(t *testing.T) {
+
+	inputEvent := cloudevents.NewEvent()
+	inputEvent.SetType(keptnv2.GetTriggeredEventType(keptnv2.EvaluationTaskName))
+	inputEvent.SetExtension(keptnContextCEExtension, "my-context")
+	inputEvent.SetExtension(keptnSpecVersionCEExtension, "0.2.0")
+	inputEvent.SetID("my-triggered-id")
+	inputEvent.SetDataContentType(cloudevents.ApplicationJSON)
+	inputEvent.SetData(cloudevents.ApplicationJSON, &keptnv2.EventData{
+		Project: "my-project",
+		Stage:   "my-stage",
+		Service: "my-service",
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+	})
+
+	type fields struct {
+		KeptnBase keptn.KeptnBase
+	}
+	type args struct {
+		data   keptn.EventProperties
+		source string
+	}
+	type wantEventProperties struct {
+		eventType        string
+		keptnContext     string
+		triggeredID      string
+		keptnSpecVersion string
+		eventData        keptn.EventProperties
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		sendEventType string
+		wantErr       bool
+		wantEvents    []wantEventProperties
+	}{
+		{
+			name: "send started event - no error",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{},
+				},
+			},
+			args: args{
+				source: "my-source",
+			},
+			sendEventType: keptnStartedEventSuffix,
+			wantErr:       false,
+			wantEvents: []wantEventProperties{
+				{
+					eventType:        keptnv2.GetStartedEventType(keptnv2.EvaluationTaskName),
+					keptnContext:     "my-context",
+					triggeredID:      "my-triggered-id",
+					keptnSpecVersion: "0.2.0",
+					eventData: &keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "send status.changed event - no error",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{},
+				},
+			},
+			args: args{
+				source: "my-source",
+			},
+			sendEventType: keptnStatusChangedEventSuffix,
+			wantErr:       false,
+			wantEvents: []wantEventProperties{
+				{
+					eventType:        keptnv2.GetStatusChangedEventType(keptnv2.EvaluationTaskName),
+					keptnContext:     "my-context",
+					triggeredID:      "my-triggered-id",
+					keptnSpecVersion: "0.2.0",
+					eventData: &keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "send finished event - no error",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{},
+				},
+			},
+			args: args{
+				source: "my-source",
+			},
+			sendEventType: keptnFinishedEventSuffix,
+			wantErr:       false,
+			wantEvents: []wantEventProperties{
+				{
+					eventType:        keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName),
+					keptnContext:     "my-context",
+					triggeredID:      "my-triggered-id",
+					keptnSpecVersion: "0.2.0",
+					eventData: &keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "send finished event with additional attributes- no error",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{},
+				},
+			},
+			args: args{
+				data: &keptnv2.EventData{
+					Result: keptnv2.ResultPass,
+				},
+				source: "my-source",
+			},
+			sendEventType: keptnFinishedEventSuffix,
+			wantErr:       false,
+			wantEvents: []wantEventProperties{
+				{
+					eventType:        keptnv2.GetFinishedEventType(keptnv2.EvaluationTaskName),
+					keptnContext:     "my-context",
+					triggeredID:      "my-triggered-id",
+					keptnSpecVersion: "0.2.0",
+					eventData: &keptnv2.EventData{
+						Project: "my-project",
+						Stage:   "my-stage",
+						Service: "my-service",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+						Result: keptnv2.ResultPass,
+					},
+				},
+			},
+		},
+		{
+			name: "send finished event - error when sending event",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{
+						Reactors: map[string]func(event cloudevents.Event) error{
+							"*": func(event cloudevents.Event) error {
+								return errors.New("")
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				data: &keptnv2.EventData{
+					Result: keptnv2.ResultPass,
+				},
+				source: "my-source",
+			},
+			sendEventType: keptnFinishedEventSuffix,
+			wantErr:       true,
+			wantEvents:    []wantEventProperties{},
+		},
+		{
+			name: "send event without source - return error",
+			fields: fields{
+				KeptnBase: keptn.KeptnBase{
+					EventSender: &fake.EventSender{
+						Reactors: map[string]func(event cloudevents.Event) error{
+							"*": func(event cloudevents.Event) error {
+								return errors.New("")
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				data: &keptnv2.EventData{
+					Result: keptnv2.ResultPass,
+				},
+				source: "",
+			},
+			sendEventType: keptnFinishedEventSuffix,
+			wantErr:       true,
+			wantEvents:    []wantEventProperties{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			k, err := NewKeptn(&inputEvent, keptn.KeptnOpts{
+				EventSender: tt.fields.KeptnBase.EventSender,
+			})
+			if err != nil {
+				t.Error(err.Error())
+			}
+			var got string
+
+			switch tt.sendEventType {
+			case keptnStartedEventSuffix:
+				got, err = k.SendTaskStartedEvent(ctx, tt.args.data, tt.args.source)
+			case keptnStatusChangedEventSuffix:
+				got, err = k.SendTaskStatusChangedEvent(ctx, tt.args.data, tt.args.source)
+			case keptnFinishedEventSuffix:
+				got, err = k.SendTaskFinishedEvent(ctx, tt.args.data, tt.args.source)
+			default:
+				return
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == "" {
+				t.Errorf("did not return event ID")
+			}
+
+			if len(k.EventSender.(*fake.EventSender).SentEvents) != len(tt.wantEvents) {
+				t.Errorf("did not receive expected number of events. Expected %d, got %d", len(tt.wantEvents), len(k.EventSender.(*fake.EventSender).SentEvents))
+			}
+
+			for index, event := range k.EventSender.(*fake.EventSender).SentEvents {
+				assert.Equal(t, event.Type(), tt.wantEvents[index].eventType)
+				triggeredID, err := event.Context.GetExtension(triggeredIDCEExtension)
+				assert.Nil(t, err)
+				assert.Equal(t, triggeredID.(string), tt.wantEvents[index].triggeredID)
+				keptnContext, err := event.Context.GetExtension(keptnContextCEExtension)
+				assert.Nil(t, err)
+				assert.Equal(t, keptnContext.(string), tt.wantEvents[index].keptnContext)
+				keptnSpecVersion, err := event.Context.GetExtension(keptnSpecVersionCEExtension)
+				assert.Nil(t, err)
+				assert.Equal(t, keptnSpecVersion.(string), tt.wantEvents[index].keptnSpecVersion)
+				data := &keptnv2.EventData{}
+				err = event.DataAs(data)
+				assert.Nil(t, err)
+				assert.EqualValues(t, data, tt.wantEvents[index].eventData)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## This PR
Introduces a new version of keptn lib with Go context propagation in the methods/functions.

### Related Issues
Part of https://github.com/keptn/enhancement-proposals/pull/30#issuecomment-920612524

### Notes
The need for this comes with our intention of adding OpenTelemetry instrumentation to Keptn. The way context propagation works in OpenTelemetry for Go is via the `context.Context` object. It is used to pass along cross-cutting concerns, such as cancellation and now, the `tracecontext` information.

Since changing the existing methods will incur a breaking API change, a new version of the package is needed.

