### PR TITLE
feat: add temporary data to keptn event

### DIFF
--- a/pkg/api/models/keptn_context_extended_c_e.go
+++ b/pkg/api/models/keptn_context_extended_c_e.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -72,4 +73,56 @@ func (ce *KeptnContextExtendedCE) Validate() error {
 		return errors.New("source must be specified")
 	}
 	return nil
+}
+
+// TemporaryData represents additional (temporary) data to be added
+// to the data section of a keptn event
+type TemporaryData interface{}
+
+// AddTemporaryDataOptions are used to modify the behavior of adding temporary
+// data to a keptn event
+type AddTemporaryDataOptions struct {
+	// OverwriteIfExisting indicates, that the data will be overwritten
+	// in case a key for that data already exists
+	OverwriteIfExisting bool
+}
+
+const temporaryDataRootKey = "temporaryData"
+
+// AddTemporaryData adds further (temporary) properties to the data section of the keptn event
+func (ce *KeptnContextExtendedCE) AddTemporaryData(key string, tmpData TemporaryData, opts AddTemporaryDataOptions) error {
+	eventData := map[string]interface{}{}
+	err := ce.DataAs(&eventData)
+	if err != nil {
+		return err
+	}
+	if temporaryData, found := eventData[temporaryDataRootKey]; found {
+		if _, kfound := temporaryData.(map[string]interface{})[key]; kfound {
+			if !opts.OverwriteIfExisting {
+				return fmt.Errorf("Key %s already exists", key)
+			}
+			temporaryData.(map[string]interface{})[key] = tmpData
+		}
+	} else {
+		eventData[temporaryDataRootKey] = map[string]interface{}{key: tmpData}
+	}
+	ce.Data = eventData
+	return nil
+}
+
+// GetTemporaryData returns the (temporary) data eventually stored in the event
+func (ce *KeptnContextExtendedCE) GetTemporaryData(key string, tmpdata interface{}) error {
+	eventData := map[string]interface{}{}
+	if err := ce.DataAs(&eventData); err != nil {
+		return err
+	}
+	if temporaryData, found := eventData[temporaryDataRootKey]; found {
+		if keyData, kfound := temporaryData.(map[string]interface{})[key]; kfound {
+			if marshalledKeyData, err := json.Marshal(keyData); err == nil {
+				return json.Unmarshal(marshalledKeyData, tmpdata)
+			}
+		}
+		return fmt.Errorf("temporary data with key %s not found", key)
+	}
+	return fmt.Errorf("temporary data with key %s not found", key)
 }

--- a/pkg/api/models/keptn_context_extended_c_e_test.go
+++ b/pkg/api/models/keptn_context_extended_c_e_test.go
@@ -210,5 +210,12 @@ func TestKeptnContextExtendedCE_TemporaryData(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, dataToAdd, dataRetrieved)
 	})
+	t.Run("get non existing temporary data", func(t *testing.T) {
+		ce, err := v0_2_0.KeptnEvent("sh.keptn.event.dev.delivery.triggered", "source", testData).Build()
+		require.Nil(t, err)
 
+		dataRetrieved := AdditionalData{}
+		err = ce.GetTemporaryData("the-key", &dataRetrieved)
+		assert.NotNil(t, err)
+	})
 }


### PR DESCRIPTION
This PR adds the possibility to easily add "temporary/additional" data to a `KeptnContextExtendedCE`.
Temporary data will be added under the `data  -> temporaryData` section of an event. Each source can add temporary data with a given `key`. The temporary data itself is unstructured. 
Example with key name `distributor` : 
![image](https://user-images.githubusercontent.com/72415058/134855275-af0cb653-6532-4c5f-856c-63ee1f60d593.png)
