### PR TITLE
feat: Update mongo DB env variables to new names according to new variables in installer chart

### DIFF
--- a/pkg/common/mongoutils/mongo.go
+++ b/pkg/common/mongoutils/mongo.go
@@ -8,17 +8,17 @@ import (
 )
 
 // GetMongoConnectionStringFromEnv returns a mongodb connection string and the database name by considering the following environment variables:
-// MONGO_DB_NAME - The name of the database within the mongodb service (e.g. keptn)
+// MONGODB_DATABASE - The name of the database within the mongodb service (e.g. keptn)
 // MONGODB_EXTERNAL_CONNECTION_STRING - If this variable is set, the function will return this value. Otherwise, it will construct the connection string from the following variables.
 // MONGODB_HOST - The host name (including the port) of the mongodb service (e.g. mongo:27017)
 // MONGODB_USER - The username of the database
 // MONGODB_PASSWORD - The password of the user
 // The resulting constructed string is compatible with the mongodb services that is deployed by default as part of Keptn core, and looks as follows:
-// mongodb://<MONGODB_USER>:<MONGODB_PASSWORD>@MONGODB_HOST>/<MONGO_DB_NAME>
+// mongodb://<MONGODB_USER>:<MONGODB_PASSWORD>@MONGODB_HOST>/<MONGODB_DATABASE>
 func GetMongoConnectionStringFromEnv() (string, string, error) {
-	mongoDBName := os.Getenv("MONGO_DB_NAME")
+	mongoDBName := os.Getenv("MONGODB_DATABASE")
 	if mongoDBName == "" {
-		return "", "", errors.New("env var 'MONGO_DB_NAME' env var must be set")
+		return "", "", errors.New("env var 'MONGODB_DATABASE' env var must be set")
 	}
 	if externalConnectionString := os.Getenv("MONGODB_EXTERNAL_CONNECTION_STRING"); externalConnectionString != "" {
 		return externalConnectionString, mongoDBName, nil

--- a/pkg/common/mongoutils/mongo_test.go
+++ b/pkg/common/mongoutils/mongo_test.go
@@ -84,7 +84,7 @@ func TestGetMongoConnectionStringFromEnv(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Setenv("MONGODB_EXTERNAL_CONNECTION_STRING", tt.externalConnectionStringEnvVar)
 			os.Setenv("MONGODB_HOST", tt.mongoDbHostEnvVar)
-			os.Setenv("MONGO_DB_NAME", tt.mongoDbNameEnvVar)
+			os.Setenv("MONGODB_DATABASE", tt.mongoDbNameEnvVar)
 			os.Setenv("MONGODB_USER", tt.mongoDbUserEnvVar)
 			os.Setenv("MONGODB_PASSWORD", tt.mongoDbPasswordEnvVar)
 			gotConnectionString, gotDbName, err := GetMongoConnectionStringFromEnv()


### PR DESCRIPTION
### This PR
* updates the mongo DB env variable so that it follows the new naming scheme that is used in the mongodb-datastore helm chart in keptn/keptn

#### Related Issues
Part of keptn/keptn#4801