### PR TITLE
feat: added custom time parsing (keptn/keptn#4788)

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -63,13 +63,6 @@ jobs:
           echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
-      - name: Temporarily disable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
-          enforce_admins: false
-
       - name: Create pre-release package
         id: create-release-package
         env:
@@ -81,14 +74,6 @@ jobs:
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
-
-      - name: Enable "include administrators" branch protection
-        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
-        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
-        with:
-          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
-          branch: ${{ github.event.repository.default_branch }}
-          enforce_admins: true
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -63,6 +63,13 @@ jobs:
           echo "" >> "${{ env.RELEASE_NOTES_FILE }}"
           echo "**GitHub Actions Run:** $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "${{ env.RELEASE_NOTES_FILE }}"
 
+      - name: Temporarily disable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: false
+
       - name: Create pre-release package
         id: create-release-package
         env:
@@ -74,6 +81,14 @@ jobs:
           echo "::set-output name=tag-name::$(git describe --tags --abbrev=0)"
           echo "⚡️ Pushing changes to remote repository..."
           git push --follow-tags
+
+      - name: Enable "include administrators" branch protection
+        uses: benjefferies/branch-protection-bot@6d0ac2b2d9bfd39794b017f8241adb7da7f0ab98 # pin@1.0.7
+        if: always() # Force to always run this step to ensure "include administrators" is always turned back on
+        with:
+          access_token: ${{ secrets.KEPTN_BOT_TOKEN }}
+          branch: ${{ github.event.repository.default_branch }}
+          enforce_admins: true
 
       - name: Create GitHub Release
         env:

--- a/pkg/common/timeutils/timeutils.go
+++ b/pkg/common/timeutils/timeutils.go
@@ -60,7 +60,6 @@ func (params *GetStartEndTimeParams) Validate() error {
 
 // GetStartEndTime parses the provided start date, end date and/or timeframe
 func GetStartEndTime(params GetStartEndTimeParams) (*time.Time, *time.Time, error) {
-	//var timeFormat string
 	var err error
 
 	// input validation

--- a/pkg/common/timeutils/timeutils.go
+++ b/pkg/common/timeutils/timeutils.go
@@ -7,7 +7,7 @@ import (
 )
 
 const KeptnTimeFormatISO8601 = "2006-01-02T15:04:05.000Z"
-const fallbackTimeformat = "2006-01-02T15:04:05"
+const fallbackTimeFormat = "2006-01-02T15:04:05"
 const defaultEvaluationTimeframe = "5m"
 
 // GetKeptnTimeStamp formats a given timestamp into the format used by
@@ -16,16 +16,16 @@ func GetKeptnTimeStamp(timestamp time.Time) string {
 	return timestamp.Format(KeptnTimeFormatISO8601)
 }
 
-// ParseTimestamp tries to parse the given timestamp using the ISO8601 format (e.g. '2006-01-02T15:04:05.000Z')
-// if this is not possible, the fallback format RFC3339  will be used, then '2006-01-02T15:04:05'
-//If this fails as well, an error is returned
+// ParseTimestamp tries to parse the given timestamp using the ISO8601 format (e.g. '2006-01-02T15:04:05.000Z').
+// If this is not possible, the fallback format RFC3339  will be used, then '2006-01-02T15:04:05'.
+// If this fails as well, an error is returned
 
 func ParseTimestamp(timestamp string) (*time.Time, error) {
 	parsedTime, err := time.Parse(KeptnTimeFormatISO8601, timestamp)
 	if err != nil {
 		parsedTime, err = time.Parse(time.RFC3339, timestamp)
 		if err != nil {
-			parsedTime, err = time.Parse(fallbackTimeformat, timestamp)
+			parsedTime, err = time.Parse(fallbackTimeFormat, timestamp)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -2,6 +2,7 @@ package timeutils
 
 import (
 	"github.com/stretchr/testify/require"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -151,62 +152,7 @@ func TestGetStartEndTime(t *testing.T) {
 func TestParseTimestamp(t *testing.T) {
 
 	correctISO8601Timestamp := "2020-01-02T15:04:05.000Z"
-	correctFallbackTimestamp := "2020-01-02T15:04:05.000000000Z"
-
-	timeObj, _ := time.Parse(KeptnTimeFormatISO8601, correctISO8601Timestamp)
-
-	type args struct {
-		timestamp string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *time.Time
-		wantErr bool
-	}{
-		{
-			name: "correct timestamp provided",
-			args: args{
-				timestamp: correctISO8601Timestamp,
-			},
-			want:    &timeObj,
-			wantErr: false,
-		},
-		{
-			name: "correct fallback timestamp provided",
-			args: args{
-				timestamp: correctFallbackTimestamp,
-			},
-			want:    &timeObj,
-			wantErr: false,
-		},
-		{
-			name: "incorrect timestamp provided",
-			args: args{
-				timestamp: "invalid",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseTimestamp(tt.args.timestamp)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseTimestamp() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseTimestamp() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParseTimestamp(t *testing.T) {
-
-	correctISO8601Timestamp := "2020-01-02T15:04:05.000Z"
-	correctFallbackTimestamp := "2020-01-02T15:04:05.000000000Z"
+	correctFallbackTimestamp := "2020-01-02T15:04:05"
 
 	timeObj, _ := time.Parse(KeptnTimeFormatISO8601, correctISO8601Timestamp)
 

--- a/pkg/common/timeutils/timeutils_test.go
+++ b/pkg/common/timeutils/timeutils_test.go
@@ -2,7 +2,6 @@ package timeutils
 
 import (
 	"github.com/stretchr/testify/require"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -202,4 +201,76 @@ func TestParseTimestamp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+
+	correctISO8601Timestamp := "2020-01-02T15:04:05.000Z"
+	correctFallbackTimestamp := "2020-01-02T15:04:05.000000000Z"
+
+	timeObj, _ := time.Parse(KeptnTimeFormatISO8601, correctISO8601Timestamp)
+
+	type args struct {
+		timestamp string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *time.Time
+		wantErr bool
+	}{
+		{
+			name: "correct timestamp provided",
+			args: args{
+				timestamp: correctISO8601Timestamp,
+			},
+			want:    &timeObj,
+			wantErr: false,
+		},
+		{
+			name: "correct fallback timestamp provided",
+			args: args{
+				timestamp: correctFallbackTimestamp,
+			},
+			want:    &timeObj,
+			wantErr: false,
+		},
+		{
+			name: "incorrect timestamp provided",
+			args: args{
+				timestamp: "invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTimestamp(tt.args.timestamp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTimestamp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseTimestamp() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVariousTimeFormat(t *testing.T) {
+	times := []string{
+		"2020-01-02T15:00:00",
+		"2020-01-02T15:00:00Z",
+		"2020-01-02T15:00:00+10:00",
+		"2020-01-02T15:00:00.000Z",
+		"2020-01-02T15:00:00.000000000Z",
+	}
+
+	for _, time := range times {
+
+		_, err := ParseTimestamp(time)
+		require.Nil(t, err)
+	}
+
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

-  change time parsing to a custom one to avoid parsing errors
-  In the order we try :
      - ISO8601 :  000Z format
      -  then RFC3339 : "2019-10-12T07:20:50.52Z" 
      - finally a fallback userfriendly format : "2006-01-02T15:04:05"
     

### Related Issues

https://github.com/keptn/keptn/issues/4788

## Notes
RFC 3339 is following the ISO 8601 DateTime format. The only difference is RFC allows us to replace “T” with “space”