### PR TITLE
fix: Make fake event sender thread safe by adding a lock

### DIFF
--- a/pkg/lib/v0_2_0/fake/events.go
+++ b/pkg/lib/v0_2_0/fake/events.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"sync"
 )
 
 // EventSender fakes the sending of CloudEvents
 type EventSender struct {
 	SentEvents []cloudevents.Event
 	Reactors   map[string]func(event cloudevents.Event) error
+	lock       sync.Mutex
 }
 
 // SendEvent fakes the sending of CloudEvents
@@ -27,6 +29,8 @@ func (es *EventSender) Send(ctx context.Context, event cloudevents.Event) error 
 			}
 		}
 	}
+	es.lock.Lock()
+	defer es.lock.Unlock()
 	es.SentEvents = append(es.SentEvents, event)
 	return nil
 }


### PR DESCRIPTION
In some cases unit tests where the fake event sender is being used were failing because the event sender internally uses the `append()` function to gather the sent events. However this function is not thread safe, which is why a lock has been added