### PR TITLE
fix: if the integrationId is not set we should not ping (keptn/keptn#6309)

### DIFF
--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -72,6 +72,10 @@ func (u *UniformHandler) getHTTPClient() *http.Client {
 }
 
 func (u *UniformHandler) Ping(integrationID string) (*models.Integration, error) {
+	if integrationID == "" {
+		return nil, errors.New("could not ping an invalid IntegrationID")
+	}
+
 	resp, err := put(u.Scheme+"://"+u.getBaseURL()+v1UniformPath+"/"+integrationID+"/ping", nil, u)
 	if err != nil {
 		return nil, errors.New(err.GetMessage())


### PR DESCRIPTION
Signed-off-by: RealAnna <anna.reale@dynatrace.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
-  avoids sending malformed pings

### Related Issues
keptn/keptn#6309
