### PR TITLE
feat: introducing `APISet` for more convenient access to keptn APIs

### DIFF
--- a/pkg/api/utils/apiServiceUtils.go
+++ b/pkg/api/utils/apiServiceUtils.go
@@ -20,18 +20,49 @@ type APIService interface {
 	getHTTPClient() *http.Client
 }
 
-func getClientTransport() *http.Transport {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		Proxy:           http.ProxyFromEnvironment,
+// createInstrumentedClientTransport tries to add support for opentelemetry
+// to the given http.Client. If httpClient is nil, a fresh http.Client
+// with opentelemetry support is created
+func createInstrumentedClientTransport(httpClient *http.Client) *http.Client {
+	if httpClient == nil {
+		return &http.Client{
+			Transport: wrapOtelTransport(getClientTransport(nil)),
+		}
 	}
-	return tr
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
+	return httpClient
 }
 
 // Wraps the provided http.RoundTripper with one that
 // starts a span and injects the span context into the outbound request headers.
-func getInstrumentedClientTransport(base http.RoundTripper) *otelhttp.Transport {
+func wrapOtelTransport(base http.RoundTripper) *otelhttp.Transport {
 	return otelhttp.NewTransport(base)
+}
+
+// getClientTransport returns a client transport which
+// skips verifying server certificates and is able to
+// read proxy configuration from environment variables
+//
+// If the givven http.RoundTripper is nil then a new http.Transport
+// is created, otherwise the given http.RoundTripper is analysed whether it
+// is of type *http.Transport. If so, the respective settings for
+// disabling server certificate verification as well as proxy server support are set
+// If not, the given http.RoundTripper is passed through untouched
+func getClientTransport(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
+		}
+		return tr
+	}
+	if tr, isDefaultTransport := rt.(*http.Transport); isDefaultTransport {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		tr.Proxy = http.ProxyFromEnvironment
+		return tr
+	}
+	return rt
+
 }
 
 func putWithEventContext(uri string, data []byte, api APIService) (*models.EventContext, *models.Error) {

--- a/pkg/api/utils/apiServiceUtils.go
+++ b/pkg/api/utils/apiServiceUtils.go
@@ -30,8 +30,8 @@ func getClientTransport() *http.Transport {
 
 // Wraps the provided http.RoundTripper with one that
 // starts a span and injects the span context into the outbound request headers.
-func getInstrumentedClientTransport() *otelhttp.Transport {
-	return otelhttp.NewTransport(getClientTransport())
+func getInstrumentedClientTransport(base http.RoundTripper) *otelhttp.Transport {
+	return otelhttp.NewTransport(base)
 }
 
 func putWithEventContext(uri string, data []byte, api APIService) (*models.EventContext, *models.Error) {

--- a/pkg/api/utils/apiServiceUtils_test.go
+++ b/pkg/api/utils/apiServiceUtils_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"net/http"
+	"testing"
+)
+
+func Test_createInstrumentedClientTransport(t *testing.T) {
+	client := createInstrumentedClientTransport(nil)
+	assert.NotNil(t, client)
+	assert.NotNil(t, client)
+	_, isOtelTransport := client.Transport.(*otelhttp.Transport)
+	assert.True(t, isOtelTransport)
+
+	client = createInstrumentedClientTransport(&http.Client{})
+	assert.NotNil(t, client)
+	_, isOtelTransport = client.Transport.(*otelhttp.Transport)
+	assert.True(t, isOtelTransport)
+
+	client = createInstrumentedClientTransport(&http.Client{Transport: &http.Transport{}})
+	assert.NotNil(t, client)
+	_, isOtelTransport = client.Transport.(*otelhttp.Transport)
+	assert.True(t, isOtelTransport)
+}

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -22,14 +22,16 @@ type APIHandler struct {
 }
 
 // NewAuthenticatedAPIHandler returns a new APIHandler that authenticates at the api-service endpoint via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	return &APIHandler{

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -24,9 +24,11 @@ type APIHandler struct {
 // NewAuthenticatedAPIHandler returns a new APIHandler that authenticates at the api-service endpoint via the provided token
 func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -27,7 +27,7 @@ func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader str
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/authUtils.go
+++ b/pkg/api/utils/authUtils.go
@@ -27,7 +27,7 @@ func NewAuthHandler(baseURL string) *AuthHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -35,9 +35,11 @@ func NewAuthHandler(baseURL string) *AuthHandler {
 // NewAuthenticatedAuthHandler returns a new AuthHandler that authenticates at the endpoint via the provided token
 func NewAuthenticatedAuthHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *AuthHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/authUtils.go
+++ b/pkg/api/utils/authUtils.go
@@ -33,14 +33,17 @@ func NewAuthHandler(baseURL string) *AuthHandler {
 }
 
 // NewAuthenticatedAuthHandler returns a new AuthHandler that authenticates at the endpoint via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedAuthHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *AuthHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
 
+	return createAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
+
+func createAuthenticatedAuthHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *AuthHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	return &AuthHandler{

--- a/pkg/api/utils/authUtils.go
+++ b/pkg/api/utils/authUtils.go
@@ -27,7 +27,7 @@ func NewAuthHandler(baseURL string) *AuthHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -38,7 +38,7 @@ func NewAuthenticatedAuthHandler(baseURL string, authToken string, authHeader st
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 
 	return createAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type KeptnInterface interface {
+	APIV1() *APIHandler
+	AuthV1() *AuthHandler
+	EventsV1() *EventHandler
+	LogsV1() *LogHandler
+	ProjectsV1() *ProjectHandler
+	ResourcesV1() *ResourceHandler
+	SecretsV1() *SecretHandler
+	SequencesV1() *SequenceControlHandler
+	ServicesV1() *ServiceHandler
+	StagesV1() *StageHandler
+	UniformV1() *UniformHandler
+}
+
+type ApiSet struct {
+	endpointURL            *url.URL
+	apiToken               string
+	apiHandler             *APIHandler
+	authHandler            *AuthHandler
+	eventHandler           *EventHandler
+	logHandler             *LogHandler
+	projectHandler         *ProjectHandler
+	resourceHandler        *ResourceHandler
+	secretHandler          *SecretHandler
+	sequenceControlHandler *SequenceControlHandler
+	serviceHandler         *ServiceHandler
+	stageHandler           *StageHandler
+	uniformHandler         *UniformHandler
+	shipyardControlHandler *ShipyardControllerHandler
+}
+
+func (c *ApiSet) APIV1() *APIHandler {
+	return c.apiHandler
+}
+
+func (c *ApiSet) AuthV1() *AuthHandler {
+	return c.authHandler
+}
+
+func (c *ApiSet) EventsV1() *EventHandler {
+	return c.eventHandler
+}
+
+func (c *ApiSet) LogsV1() *LogHandler {
+	return c.logHandler
+}
+
+func (c *ApiSet) ProjectsV1() *ProjectHandler {
+	return c.projectHandler
+}
+
+func (c *ApiSet) ResourcesV1() *ResourceHandler {
+	return c.resourceHandler
+}
+
+func (c *ApiSet) SecretsV1() *SecretHandler {
+	return c.secretHandler
+}
+
+func (c *ApiSet) SequencesV1() *SequenceControlHandler {
+	return c.sequenceControlHandler
+}
+
+func (c *ApiSet) ServicesV1() *ServiceHandler {
+	return c.serviceHandler
+}
+
+func (c *ApiSet) StagesV1() *StageHandler {
+	return c.stageHandler
+}
+
+func (c *ApiSet) UniformV1() *UniformHandler {
+	return c.uniformHandler
+}
+
+func (c *ApiSet) ShipyardControlHandlerV1() *ShipyardControllerHandler {
+	return c.shipyardControlHandler
+}
+
+func (c *ApiSet) Token() string {
+	return c.apiToken
+}
+
+func (c *ApiSet) Endpoint() *url.URL {
+	return c.endpointURL
+}
+
+func NewApiSet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*ApiSet, error) {
+	var as ApiSet
+	as.apiHandler = NewAuthenticatedAPIHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.logHandler = NewAuthenticatedLogHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.eventHandler = NewAuthenticatedEventHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.projectHandler = NewAuthenticatedProjectHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.resourceHandler = NewAuthenticatedResourceHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.secretHandler = NewAuthenticatedSecretHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.sequenceControlHandler = NewAuthenticatedSequenceControlHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.serviceHandler = NewAuthenticatedServiceHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.shipyardControlHandler = NewAuthenticatedShipyardControllerHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.stageHandler = NewAuthenticatedStageHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.uniformHandler = NewAuthenticatedUniformHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.apiToken = authToken
+	url, _ := url.Parse(baseURL)
+	as.endpointURL = url
+	return &as, nil
+}

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -19,6 +19,7 @@ type KeptnInterface interface {
 	UniformV1() *UniformHandler
 }
 
+// ApiSet contains the API utils for all keptn APIs
 type ApiSet struct {
 	endpointURL            *url.URL
 	apiToken               string
@@ -36,77 +37,92 @@ type ApiSet struct {
 	shipyardControlHandler *ShipyardControllerHandler
 }
 
+// APIV1 retrieves the APIHandler
 func (c *ApiSet) APIV1() *APIHandler {
 	return c.apiHandler
 }
 
+// AuthV1 retrieves the AuthHandler
 func (c *ApiSet) AuthV1() *AuthHandler {
 	return c.authHandler
 }
 
+// EventsV1 retrieves the EventHandler
 func (c *ApiSet) EventsV1() *EventHandler {
 	return c.eventHandler
 }
 
+// LogsV1 retrieves the LogHandler
 func (c *ApiSet) LogsV1() *LogHandler {
 	return c.logHandler
 }
 
+// ProjectsV1 retrieves the ProjectHandler
 func (c *ApiSet) ProjectsV1() *ProjectHandler {
 	return c.projectHandler
 }
 
+// ResourcesV1 retrieves the ResourceHandler
 func (c *ApiSet) ResourcesV1() *ResourceHandler {
 	return c.resourceHandler
 }
 
+// SecretsV1 retrieves the SecretHandler
 func (c *ApiSet) SecretsV1() *SecretHandler {
 	return c.secretHandler
 }
 
+// SequencesV1 retrieves the SequenceControlHandler
 func (c *ApiSet) SequencesV1() *SequenceControlHandler {
 	return c.sequenceControlHandler
 }
 
+// ServicesV1 retrieves the ServiceHandler
 func (c *ApiSet) ServicesV1() *ServiceHandler {
 	return c.serviceHandler
 }
 
+// StagesV1 retrieves the StageHandler
 func (c *ApiSet) StagesV1() *StageHandler {
 	return c.stageHandler
 }
 
+// UniformV1 retrieves the UniformHandler
 func (c *ApiSet) UniformV1() *UniformHandler {
 	return c.uniformHandler
 }
 
+// ShipyardControlHandlerV1 retrieves the ShipyardControllerHandler
 func (c *ApiSet) ShipyardControlHandlerV1() *ShipyardControllerHandler {
 	return c.shipyardControlHandler
 }
 
+// Token retrieves the API token
 func (c *ApiSet) Token() string {
 	return c.apiToken
 }
 
+// Endpoint retrieves the base API endpoint URL
 func (c *ApiSet) Endpoint() *url.URL {
 	return c.endpointURL
 }
 
+// NewApiSet creates a new ApiSet
 func NewApiSet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*ApiSet, error) {
 	var as ApiSet
-	as.apiHandler = NewAuthenticatedAPIHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.logHandler = NewAuthenticatedLogHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.eventHandler = NewAuthenticatedEventHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.projectHandler = NewAuthenticatedProjectHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.resourceHandler = NewAuthenticatedResourceHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.secretHandler = NewAuthenticatedSecretHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.sequenceControlHandler = NewAuthenticatedSequenceControlHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.serviceHandler = NewAuthenticatedServiceHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.shipyardControlHandler = NewAuthenticatedShipyardControllerHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.stageHandler = NewAuthenticatedStageHandler(baseURL, authToken, "x-token", httpClient, scheme)
-	as.uniformHandler = NewAuthenticatedUniformHandler(baseURL, authToken, "x-token", httpClient, scheme)
+	as.apiHandler = NewAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.logHandler = NewAuthenticatedLogHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.eventHandler = NewAuthenticatedEventHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.projectHandler = NewAuthenticatedProjectHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.resourceHandler = NewAuthenticatedResourceHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.secretHandler = NewAuthenticatedSecretHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.sequenceControlHandler = NewAuthenticatedSequenceControlHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.serviceHandler = NewAuthenticatedServiceHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.shipyardControlHandler = NewAuthenticatedShipyardControllerHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.stageHandler = NewAuthenticatedStageHandler(baseURL, authToken, authHeader, httpClient, scheme)
+	as.uniformHandler = NewAuthenticatedUniformHandler(baseURL, authToken, authHeader, httpClient, scheme)
 	as.apiToken = authToken
 	url, _ := url.Parse(baseURL)
 	as.endpointURL = url

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -109,7 +110,13 @@ func (c *ApiSet) Endpoint() *url.URL {
 
 // NewApiSet creates a new ApiSet
 func NewApiSet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*ApiSet, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create apiset: %w", err)
+	}
 	var as ApiSet
+	as.endpointURL = u
+	as.apiToken = authToken
 	as.apiHandler = NewAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)
 	as.authHandler = NewAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
 	as.logHandler = NewAuthenticatedLogHandler(baseURL, authToken, authHeader, httpClient, scheme)
@@ -123,8 +130,5 @@ func NewApiSet(baseURL string, authToken string, authHeader string, httpClient *
 	as.shipyardControlHandler = NewAuthenticatedShipyardControllerHandler(baseURL, authToken, authHeader, httpClient, scheme)
 	as.stageHandler = NewAuthenticatedStageHandler(baseURL, authToken, authHeader, httpClient, scheme)
 	as.uniformHandler = NewAuthenticatedUniformHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.apiToken = authToken
-	url, _ := url.Parse(baseURL)
-	as.endpointURL = url
 	return &as, nil
 }

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -20,8 +20,8 @@ type KeptnInterface interface {
 	UniformV1() *UniformHandler
 }
 
-// ApiSet contains the API utils for all keptn APIs
-type ApiSet struct {
+// APISet contains the API utils for all keptn APIs
+type APISet struct {
 	endpointURL            *url.URL
 	apiToken               string
 	apiHandler             *APIHandler
@@ -39,82 +39,82 @@ type ApiSet struct {
 }
 
 // APIV1 retrieves the APIHandler
-func (c *ApiSet) APIV1() *APIHandler {
+func (c *APISet) APIV1() *APIHandler {
 	return c.apiHandler
 }
 
 // AuthV1 retrieves the AuthHandler
-func (c *ApiSet) AuthV1() *AuthHandler {
+func (c *APISet) AuthV1() *AuthHandler {
 	return c.authHandler
 }
 
 // EventsV1 retrieves the EventHandler
-func (c *ApiSet) EventsV1() *EventHandler {
+func (c *APISet) EventsV1() *EventHandler {
 	return c.eventHandler
 }
 
 // LogsV1 retrieves the LogHandler
-func (c *ApiSet) LogsV1() *LogHandler {
+func (c *APISet) LogsV1() *LogHandler {
 	return c.logHandler
 }
 
 // ProjectsV1 retrieves the ProjectHandler
-func (c *ApiSet) ProjectsV1() *ProjectHandler {
+func (c *APISet) ProjectsV1() *ProjectHandler {
 	return c.projectHandler
 }
 
 // ResourcesV1 retrieves the ResourceHandler
-func (c *ApiSet) ResourcesV1() *ResourceHandler {
+func (c *APISet) ResourcesV1() *ResourceHandler {
 	return c.resourceHandler
 }
 
 // SecretsV1 retrieves the SecretHandler
-func (c *ApiSet) SecretsV1() *SecretHandler {
+func (c *APISet) SecretsV1() *SecretHandler {
 	return c.secretHandler
 }
 
 // SequencesV1 retrieves the SequenceControlHandler
-func (c *ApiSet) SequencesV1() *SequenceControlHandler {
+func (c *APISet) SequencesV1() *SequenceControlHandler {
 	return c.sequenceControlHandler
 }
 
 // ServicesV1 retrieves the ServiceHandler
-func (c *ApiSet) ServicesV1() *ServiceHandler {
+func (c *APISet) ServicesV1() *ServiceHandler {
 	return c.serviceHandler
 }
 
 // StagesV1 retrieves the StageHandler
-func (c *ApiSet) StagesV1() *StageHandler {
+func (c *APISet) StagesV1() *StageHandler {
 	return c.stageHandler
 }
 
 // UniformV1 retrieves the UniformHandler
-func (c *ApiSet) UniformV1() *UniformHandler {
+func (c *APISet) UniformV1() *UniformHandler {
 	return c.uniformHandler
 }
 
 // ShipyardControlHandlerV1 retrieves the ShipyardControllerHandler
-func (c *ApiSet) ShipyardControlHandlerV1() *ShipyardControllerHandler {
+func (c *APISet) ShipyardControlHandlerV1() *ShipyardControllerHandler {
 	return c.shipyardControlHandler
 }
 
 // Token retrieves the API token
-func (c *ApiSet) Token() string {
+func (c *APISet) Token() string {
 	return c.apiToken
 }
 
 // Endpoint retrieves the base API endpoint URL
-func (c *ApiSet) Endpoint() *url.URL {
+func (c *APISet) Endpoint() *url.URL {
 	return c.endpointURL
 }
 
-// NewApiSet creates a new ApiSet
-func NewApiSet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*ApiSet, error) {
+// NewAPISet creates a new APISet
+func NewAPISet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*APISet, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create apiset: %w", err)
 	}
-	var as ApiSet
+	var as APISet
 	as.endpointURL = u
 	as.apiToken = authToken
 	as.apiHandler = NewAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)

--- a/pkg/api/utils/client_test.go
+++ b/pkg/api/utils/client_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 func TestApiSetWithInvalidURL(t *testing.T) {
-	apiSet, err := NewApiSet("://http.lol", "a-token", "x-token", nil, "http")
+	apiSet, err := NewAPISet("://http.lol", "a-token", "x-token", nil, "http")
 	assert.Nil(t, apiSet)
 	assert.Error(t, err)
 }
 
 func TestApiSetCreatesHandlers(t *testing.T) {
-	apiSet, err := NewApiSet("http://base-url.com", "a-token", "x-token", nil, "http")
+	apiSet, err := NewAPISet("http://base-url.com", "a-token", "x-token", nil, "http")
 	assert.NoError(t, err)
 	assert.Equal(t, "a-token", apiSet.Token())
 	assert.Equal(t, "http://base-url.com", apiSet.Endpoint().String())

--- a/pkg/api/utils/client_test.go
+++ b/pkg/api/utils/client_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestApiSetWithInvalidURL(t *testing.T) {
+	apiSet, err := NewApiSet("://http.lol", "a-token", "x-token", nil, "http")
+	assert.Nil(t, apiSet)
+	assert.Error(t, err)
+}
+
+func TestApiSetCreatesHandlers(t *testing.T) {
+	apiSet, err := NewApiSet("http://base-url.com", "a-token", "x-token", nil, "http")
+	assert.NoError(t, err)
+	assert.Equal(t, "a-token", apiSet.Token())
+	assert.Equal(t, "http://base-url.com", apiSet.Endpoint().String())
+	assert.NotNil(t, apiSet.UniformV1())
+	assert.NotNil(t, apiSet.Endpoint())
+	assert.NotNil(t, apiSet.ShipyardControlHandlerV1())
+	assert.NotNil(t, apiSet.StagesV1())
+	assert.NotNil(t, apiSet.ServicesV1())
+	assert.NotNil(t, apiSet.SequencesV1())
+	assert.NotNil(t, apiSet.SecretsV1())
+	assert.NotNil(t, apiSet.ProjectsV1())
+	assert.NotNil(t, apiSet.APIV1())
+	assert.NotNil(t, apiSet.EventsV1())
+	assert.NotNil(t, apiSet.AuthV1())
+	assert.NotNil(t, apiSet.ResourcesV1())
+	assert.NotNil(t, apiSet.LogsV1())
+}

--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -47,7 +47,7 @@ func NewEventHandler(baseURL string) *EventHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -57,9 +57,11 @@ const mongodbDatastoreServiceBaseUrl = "mongodb-datastore"
 // NewAuthenticatedEventHandler returns a new EventHandler that authenticates at the endpoint via the provided token
 func NewAuthenticatedEventHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *EventHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -55,14 +55,16 @@ func NewEventHandler(baseURL string) *EventHandler {
 const mongodbDatastoreServiceBaseUrl = "mongodb-datastore"
 
 // NewAuthenticatedEventHandler returns a new EventHandler that authenticates at the endpoint via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedEventHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *EventHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedEventHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedEventHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *EventHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/pkg/api/utils/eventUtils.go
+++ b/pkg/api/utils/eventUtils.go
@@ -47,7 +47,7 @@ func NewEventHandler(baseURL string) *EventHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -60,7 +60,7 @@ func NewAuthenticatedEventHandler(baseURL string, authToken string, authHeader s
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedEventHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/logUtils.go
+++ b/pkg/api/utils/logUtils.go
@@ -51,7 +51,7 @@ func NewLogHandler(baseURL string) *LogHandler {
 		BaseURL:      baseURL,
 		AuthHeader:   "",
 		AuthToken:    "",
-		HTTPClient:   &http.Client{Transport: getClientTransport()},
+		HTTPClient:   &http.Client{Transport: getClientTransport(nil)},
 		Scheme:       "http",
 		LogCache:     []models.LogEntry{},
 		TheClock:     clock.New(),
@@ -65,7 +65,7 @@ func NewAuthenticatedLogHandler(baseURL string, authToken string, authHeader str
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+	httpClient.Transport = getClientTransport(httpClient.Transport)
 	return createAuthenticatedLogHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/logUtils.go
+++ b/pkg/api/utils/logUtils.go
@@ -61,9 +61,10 @@ func NewLogHandler(baseURL string) *LogHandler {
 
 func NewAuthenticatedLogHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *LogHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getClientTransport(),
+		}
 	}
-	httpClient.Transport = getClientTransport()
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/logUtils.go
+++ b/pkg/api/utils/logUtils.go
@@ -59,13 +59,17 @@ func NewLogHandler(baseURL string) *LogHandler {
 	}
 }
 
+// NewAuthenticatedLogHandler returns a new EventHandler that authenticates at the endpoint via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedLogHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *LogHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getClientTransport(),
-		}
+		httpClient = &http.Client{}
 	}
+	httpClient.Transport = getClientTransport()
+	return createAuthenticatedLogHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedLogHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *LogHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -39,14 +39,16 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 
 // NewAuthenticatedProjectHandler returns a new ProjectHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
+// Deprecated: use APISet instead
 func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthProjectHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -32,7 +32,7 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -44,7 +44,7 @@ func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthProjectHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -32,7 +32,7 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -41,9 +41,11 @@ func NewProjectHandler(baseURL string) *ProjectHandler {
 // and sends all requests directly to the configuration-service
 func NewAuthenticatedProjectHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ProjectHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -49,14 +49,16 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 
 // NewAuthenticatedResourceHandler returns a new ResourceHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
+// Deprecated: use APISet instead
 func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ResourceHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedResourceHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ResourceHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -42,7 +42,7 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -54,7 +54,7 @@ func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeade
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedResourceHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -42,7 +42,7 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -51,9 +51,11 @@ func NewResourceHandler(baseURL string) *ResourceHandler {
 // and sends all requests directly to the configuration-service
 func NewAuthenticatedResourceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ResourceHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/secretUtils.go
+++ b/pkg/api/utils/secretUtils.go
@@ -48,14 +48,16 @@ func NewSecretHandler(baseURL string) *SecretHandler {
 
 // NewAuthenticatedSecretHandler returns a new SecretHandler that authenticates at the api via the provided token
 // and sends all requests directly to the secret-service
+// Deprecated: use APISet instead
 func NewAuthenticatedSecretHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SecretHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedSecretHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedSecretHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SecretHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 

--- a/pkg/api/utils/secretUtils.go
+++ b/pkg/api/utils/secretUtils.go
@@ -41,7 +41,7 @@ func NewSecretHandler(baseURL string) *SecretHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -53,7 +53,7 @@ func NewAuthenticatedSecretHandler(baseURL string, authToken string, authHeader 
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedSecretHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/secretUtils.go
+++ b/pkg/api/utils/secretUtils.go
@@ -41,7 +41,7 @@ func NewSecretHandler(baseURL string) *SecretHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -50,9 +50,11 @@ func NewSecretHandler(baseURL string) *SecretHandler {
 // and sends all requests directly to the secret-service
 func NewAuthenticatedSecretHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SecretHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/sequenceUtils.go
+++ b/pkg/api/utils/sequenceUtils.go
@@ -68,14 +68,17 @@ func NewSequenceControlHandler(baseURL string) *SequenceControlHandler {
 	}
 }
 
+// NewAuthenticatedSequenceControlHandler returns a new SequenceControlHandler that authenticates at the api via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedSequenceControlHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SequenceControlHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedSequenceControlHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedSequenceControlHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SequenceControlHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")

--- a/pkg/api/utils/sequenceUtils.go
+++ b/pkg/api/utils/sequenceUtils.go
@@ -63,7 +63,7 @@ func NewSequenceControlHandler(baseURL string) *SequenceControlHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -74,7 +74,7 @@ func NewAuthenticatedSequenceControlHandler(baseURL string, authToken string, au
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedSequenceControlHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/sequenceUtils.go
+++ b/pkg/api/utils/sequenceUtils.go
@@ -63,16 +63,18 @@ func NewSequenceControlHandler(baseURL string) *SequenceControlHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
 
 func NewAuthenticatedSequenceControlHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *SequenceControlHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -32,7 +32,7 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -41,9 +41,11 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 // and sends all requests directly to the configuration-service
 func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ServiceHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -39,14 +39,16 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 
 // NewAuthenticatedServiceHandler returns a new ServiceHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
+// Deprecated: use APISet instead
 func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ServiceHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedServiceHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedServiceHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ServiceHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -32,7 +32,7 @@ func NewServiceHandler(baseURL string) *ServiceHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -44,7 +44,7 @@ func NewAuthenticatedServiceHandler(baseURL string, authToken string, authHeader
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedServiceHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/shipyardControllerUtils.go
+++ b/pkg/api/utils/shipyardControllerUtils.go
@@ -35,7 +35,7 @@ func NewShipyardControllerHandler(baseURL string) *ShipyardControllerHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport()},
+		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
 		Scheme:     "http",
 	}
 }
@@ -44,9 +44,11 @@ func NewShipyardControllerHandler(baseURL string) *ShipyardControllerHandler {
 // and sends all requests directly to the configuration-service
 func NewAuthenticatedShipyardControllerHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ShipyardControllerHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")

--- a/pkg/api/utils/shipyardControllerUtils.go
+++ b/pkg/api/utils/shipyardControllerUtils.go
@@ -42,14 +42,16 @@ func NewShipyardControllerHandler(baseURL string) *ShipyardControllerHandler {
 
 // NewAuthenticatedShipyardControllerHandler returns a new ShipyardControllerHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
+// Deprecated: use APISet instead
 func NewAuthenticatedShipyardControllerHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ShipyardControllerHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedShipyardControllerHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedShipyardControllerHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *ShipyardControllerHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 

--- a/pkg/api/utils/shipyardControllerUtils.go
+++ b/pkg/api/utils/shipyardControllerUtils.go
@@ -35,7 +35,7 @@ func NewShipyardControllerHandler(baseURL string) *ShipyardControllerHandler {
 		BaseURL:    baseURL,
 		AuthHeader: "",
 		AuthToken:  "",
-		HTTPClient: &http.Client{Transport: getInstrumentedClientTransport(getClientTransport())},
+		HTTPClient: &http.Client{Transport: wrapOtelTransport(getClientTransport(nil))},
 		Scheme:     "http",
 	}
 }
@@ -47,7 +47,7 @@ func NewAuthenticatedShipyardControllerHandler(baseURL string, authToken string,
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedShipyardControllerHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -42,9 +42,11 @@ func NewStageHandler(baseURL string) *StageHandler {
 // and sends all requests directly to the configuration-service
 func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getInstrumentedClientTransport()
+	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -45,7 +45,7 @@ func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader s
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	httpClient.Transport = wrapOtelTransport(getClientTransport(httpClient.Transport))
 	return createAuthenticatedStageHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -40,17 +40,20 @@ func NewStageHandler(baseURL string) *StageHandler {
 
 // NewAuthenticatedStageHandler returns a new StageHandler that authenticates at the api via the provided token
 // and sends all requests directly to the configuration-service
+// Deprecated: use APISet instead
 func NewAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getInstrumentedClientTransport(httpClient.Transport)
+	httpClient.Transport = getInstrumentedClientTransport(getClientTransport())
+	return createAuthenticatedStageHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
+
+func createAuthenticatedStageHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *StageHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
-
 	baseURL = strings.TrimRight(baseURL, "/")
+
 	if !strings.HasSuffix(baseURL, shipyardControllerBaseURL) {
 		baseURL += "/" + shipyardControllerBaseURL
 	}

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -34,13 +34,17 @@ func NewUniformHandler(baseURL string) *UniformHandler {
 	}
 }
 
+// NewAuthenticatedSequenceControlHandler returns a new UniformHandler that authenticates at the api via the provided token
+// Deprecated: use APISet instead
 func NewAuthenticatedUniformHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *UniformHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Transport: getInstrumentedClientTransport(getClientTransport()),
-		}
+		httpClient = &http.Client{}
 	}
+	httpClient.Transport = getClientTransport()
+	return createAuthenticatedUniformHandler(baseURL, authToken, authHeader, httpClient, scheme)
+}
 
+func createAuthenticatedUniformHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *UniformHandler {
 	baseURL = httputils.TrimHTTPScheme(baseURL)
 	baseURL = strings.TrimRight(baseURL, "/")
 

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -36,9 +36,11 @@ func NewUniformHandler(baseURL string) *UniformHandler {
 
 func NewAuthenticatedUniformHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *UniformHandler {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		httpClient = &http.Client{
+			Transport: getInstrumentedClientTransport(getClientTransport()),
+		}
 	}
-	httpClient.Transport = getClientTransport()
+
 	baseURL = httputils.TrimHTTPScheme(baseURL)
 	baseURL = strings.TrimRight(baseURL, "/")
 

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -29,18 +29,18 @@ func NewUniformHandler(baseURL string) *UniformHandler {
 		BaseURL:    baseURL,
 		AuthToken:  "",
 		AuthHeader: "",
-		HTTPClient: &http.Client{Transport: getClientTransport()},
+		HTTPClient: &http.Client{Transport: getClientTransport(nil)},
 		Scheme:     "http",
 	}
 }
 
-// NewAuthenticatedSequenceControlHandler returns a new UniformHandler that authenticates at the api via the provided token
+// NewAuthenticatedUniformHandler returns a new UniformHandler that authenticates at the api via the provided token
 // Deprecated: use APISet instead
 func NewAuthenticatedUniformHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *UniformHandler {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
-	httpClient.Transport = getClientTransport()
+	httpClient.Transport = getClientTransport(httpClient.Transport)
 	return createAuthenticatedUniformHandler(baseURL, authToken, authHeader, httpClient, scheme)
 }
 


### PR DESCRIPTION
This PR aims to add a more convenient way to retrieve Keptn API compeonents, especially when working with multiple APIs.

Usage: initialize ApiSet once (like you've done before for a specific handler), e.g.:
```go
apiset, err := apiutils.NewAPISet(baseURL, authToken, authHeader, client, scheme)
``` 
then use the `apiset` to retrieve APIs of interest to work with: e.g.:
```go
apiset.ProjectsV1().GetProject(project)
apiset.SecretsV1().CreateSecret(secret)
...
```


