### PR TITLE
chore: enhance configuration of APISet

### DIFF
--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -24,6 +24,9 @@ type KeptnInterface interface {
 type APISet struct {
 	endpointURL            *url.URL
 	apiToken               string
+	authHeader             string
+	scheme                 string
+	httpClient             *http.Client
 	apiHandler             *APIHandler
 	authHandler            *AuthHandler
 	eventHandler           *EventHandler
@@ -108,27 +111,53 @@ func (c *APISet) Endpoint() *url.URL {
 	return c.endpointURL
 }
 
-// NewAPISet creates a new APISet
-func NewAPISet(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) (*APISet, error) {
+// WithAuthToken sets the given auth token.
+// Optionally a custom auth header can be set (default x-token)
+func WithAuthToken(authToken string, authHeader ...string) func(*APISet) {
+	aHeader := "x-token"
+	if len(authHeader) > 0 {
+		aHeader = authHeader[0]
+	}
+	return func(a *APISet) {
+		a.apiToken = authToken
+		a.authHeader = aHeader
+	}
+}
+
+// WithHTTPClient configures a custom http client to use
+func WithHTTPClient(client *http.Client) func(*APISet) {
+	return func(a *APISet) {
+		a.httpClient = client
+	}
+}
+
+// New creates a new APISet instance
+func New(baseURL string, options ...func(*APISet)) (*APISet, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create apiset: %w", err)
 	}
-	httpClient = createInstrumentedClientTransport(httpClient)
-	var as APISet
+	as := &APISet{}
+	for _, o := range options {
+		o(as)
+	}
 	as.endpointURL = u
-	as.apiToken = authToken
-	as.apiHandler = createAuthenticatedAPIHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.authHandler = createAuthenticatedAuthHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.logHandler = createAuthenticatedLogHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.eventHandler = createAuthenticatedEventHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.projectHandler = createAuthProjectHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.resourceHandler = createAuthenticatedResourceHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.secretHandler = createAuthenticatedSecretHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.sequenceControlHandler = createAuthenticatedSequenceControlHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.serviceHandler = createAuthenticatedServiceHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.shipyardControlHandler = createAuthenticatedShipyardControllerHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.stageHandler = createAuthenticatedStageHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	as.uniformHandler = createAuthenticatedUniformHandler(baseURL, authToken, authHeader, httpClient, scheme)
-	return &as, nil
+	if as.scheme == "" {
+		as.scheme = u.Scheme
+	}
+	as.httpClient = createInstrumentedClientTransport(as.httpClient)
+
+	as.apiHandler = createAuthenticatedAPIHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.authHandler = createAuthenticatedAuthHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.logHandler = createAuthenticatedLogHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.eventHandler = createAuthenticatedEventHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.projectHandler = createAuthProjectHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.resourceHandler = createAuthenticatedResourceHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.secretHandler = createAuthenticatedSecretHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.sequenceControlHandler = createAuthenticatedSequenceControlHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.serviceHandler = createAuthenticatedServiceHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.shipyardControlHandler = createAuthenticatedShipyardControllerHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.stageHandler = createAuthenticatedStageHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	as.uniformHandler = createAuthenticatedUniformHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
+	return as, nil
 }

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -131,6 +131,14 @@ func WithHTTPClient(client *http.Client) func(*APISet) {
 	}
 }
 
+// WithScheme sets the scheme
+// If this option is not used, then default scheme "http" is used by the APISet
+func WithScheme(scheme string) func(*APISet) {
+	return func(a *APISet) {
+		a.scheme = scheme
+	}
+}
+
 // New creates a new APISet instance
 func New(baseURL string, options ...func(*APISet)) (*APISet, error) {
 	u, err := url.Parse(baseURL)
@@ -142,10 +150,15 @@ func New(baseURL string, options ...func(*APISet)) (*APISet, error) {
 		o(as)
 	}
 	as.endpointURL = u
-	if as.scheme == "" {
-		as.scheme = u.Scheme
-	}
 	as.httpClient = createInstrumentedClientTransport(as.httpClient)
+
+	if as.scheme == "" {
+		if as.endpointURL.Scheme != "" {
+			as.scheme = u.Scheme
+		} else {
+			as.scheme = "http"
+		}
+	}
 
 	as.apiHandler = createAuthenticatedAPIHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)
 	as.authHandler = createAuthenticatedAuthHandler(baseURL, as.apiToken, as.authHeader, as.httpClient, as.scheme)

--- a/pkg/api/utils/client_test.go
+++ b/pkg/api/utils/client_test.go
@@ -32,8 +32,26 @@ func TestApiSetCreatesHandlers(t *testing.T) {
 	assert.NotNil(t, apiSet.LogsV1())
 }
 
+func TestAPISetDefaultValues(t *testing.T) {
+	apiSet, err := New("base-url.com")
+	assert.Nil(t, err)
+	assert.NotNil(t, apiSet)
+	assert.Equal(t, "http", apiSet.scheme)
+	assert.Equal(t, "", apiSet.authHeader)
+	assert.Equal(t, "", apiSet.apiToken)
+	assert.NotNil(t, apiSet.httpClient)
+
+	apiSet, err = New("https://base-url.com")
+	assert.Nil(t, err)
+	assert.NotNil(t, apiSet)
+	assert.Equal(t, "https", apiSet.scheme)
+	assert.Equal(t, "", apiSet.authHeader)
+	assert.Equal(t, "", apiSet.apiToken)
+	assert.NotNil(t, apiSet.httpClient)
+}
+
 func TestAPISetWithOptions(t *testing.T) {
-	apiSet, err := New("https://base-url.com", WithAuthToken("a-token"), WithHTTPClient(&http.Client{}))
+	apiSet, err := New("base-url.com", WithAuthToken("a-token"), WithHTTPClient(&http.Client{}), WithScheme("https"))
 	assert.NoError(t, err)
 	assert.Equal(t, "a-token", apiSet.Token())
 	assert.Equal(t, "x-token", apiSet.authHeader)

--- a/pkg/api/utils/client_test.go
+++ b/pkg/api/utils/client_test.go
@@ -2,20 +2,21 @@ package api
 
 import (
 	"github.com/stretchr/testify/assert"
+	"net/http"
 	"testing"
 )
 
 func TestApiSetWithInvalidURL(t *testing.T) {
-	apiSet, err := NewAPISet("://http.lol", "a-token", "x-token", nil, "http")
+	apiSet, err := New("://http.lol")
 	assert.Nil(t, apiSet)
 	assert.Error(t, err)
 }
 
 func TestApiSetCreatesHandlers(t *testing.T) {
-	apiSet, err := NewAPISet("http://base-url.com", "a-token", "x-token", nil, "http")
+	apiSet, err := New("http://base-url.com")
 	assert.NoError(t, err)
-	assert.Equal(t, "a-token", apiSet.Token())
 	assert.Equal(t, "http://base-url.com", apiSet.Endpoint().String())
+	assert.Equal(t, "http", apiSet.scheme)
 	assert.NotNil(t, apiSet.UniformV1())
 	assert.NotNil(t, apiSet.Endpoint())
 	assert.NotNil(t, apiSet.ShipyardControlHandlerV1())
@@ -29,4 +30,13 @@ func TestApiSetCreatesHandlers(t *testing.T) {
 	assert.NotNil(t, apiSet.AuthV1())
 	assert.NotNil(t, apiSet.ResourcesV1())
 	assert.NotNil(t, apiSet.LogsV1())
+}
+
+func TestAPISetWithOptions(t *testing.T) {
+	apiSet, err := New("https://base-url.com", WithAuthToken("a-token"), WithHTTPClient(&http.Client{}))
+	assert.NoError(t, err)
+	assert.Equal(t, "a-token", apiSet.Token())
+	assert.Equal(t, "x-token", apiSet.authHeader)
+	assert.Equal(t, "https", apiSet.scheme)
+	assert.NotNil(t, apiSet.httpClient)
 }


### PR DESCRIPTION
This PR enhances the configuration of an APISet.
Previously the constructor method for an APISet had quite some arguments which all needed to be passed by the user:
```
apiutils.NewAPISet(baseURL, authToken, authHeader, client, scheme)
```
Now, the only required argument to pass is `baseURL`. Additionally the constructor method was renamed to just `New()`
```
apiutils.New(baseURL)
```
The equivalent way of creating a APISet like above would be:
```
apiutils.New(baseURL, WithAuthToken(authToken),WithClient(client))
``` 

:exclamation: Note that this API is not yet released and is only used in CLI so far, for which a follow-up PR will be made.
