### PR TITLE
fix: Revert old getters and deprecate them

### DIFF
--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -24,17 +24,17 @@ var ResourceNotFoundError = errors.New("Resource not found")
 type ResourcesV1Interface interface {
 	CreateResources(project string, stage string, service string, resources []*models.Resource) (*models.EventContext, *models.Error)
 	CreateProjectResources(project string, resources []*models.Resource) (string, error)
-	GetProjectResource(project string, resourceURI string, options ...GetOption) (*models.Resource, error)
+	GetProjectResource(project string, resourceURI string) (*models.Resource, error)
 	UpdateProjectResource(project string, resource *models.Resource) (string, error)
 	DeleteProjectResource(project string, resourceURI string) error
 	UpdateProjectResources(project string, resources []*models.Resource) (string, error)
 	CreateStageResources(project string, stage string, resources []*models.Resource) (string, error)
-	GetStageResource(project string, stage string, resourceURI string, options ...GetOption) (*models.Resource, error)
+	GetStageResource(project string, stage string, resourceURI string) (*models.Resource, error)
 	UpdateStageResource(project string, stage string, resource *models.Resource) (string, error)
 	UpdateStageResources(project string, stage string, resources []*models.Resource) (string, error)
 	DeleteStageResource(project string, stage string, resourceURI string) error
 	CreateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error)
-	GetServiceResource(project string, stage string, service string, resourceURI string, options ...GetOption) (*models.Resource, error)
+	GetServiceResource(project string, stage string, service string, resourceURI string) (*models.Resource, error)
 	UpdateServiceResource(project string, stage string, service string, resource *models.Resource) (string, error)
 	UpdateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error)
 	DeleteServiceResource(project string, stage string, service string, resourceURI string) error
@@ -405,17 +405,17 @@ func (r *ResourceHandler) GetResource(scope ResourceScope, options ...GetOption)
 
 func (r *ResourceHandler) DeleteResource(scope ResourceScope, options ...GetOption) error {
 	buildURI := r.buildResourceURI(scope)
-	return r.deleteResource(buildURI)
+	return r.deleteResource(r.applyOptions(buildURI, options))
 }
 
 func (r *ResourceHandler) UpdateResource(resource *models.Resource, scope ResourceScope, options ...GetOption) (string, error) {
 	buildURI := r.buildResourceURI(scope)
-	return r.updateResource(buildURI, resource)
+	return r.updateResource(r.applyOptions(buildURI, options), resource)
 }
 
 func (r *ResourceHandler) CreateResource(resource []*models.Resource, scope ResourceScope, options ...GetOption) (string, error) {
 	buildURI := r.buildResourceURI(scope)
-	return r.createResources(buildURI, resource)
+	return r.createResources(r.applyOptions(buildURI, options), resource)
 }
 
 func (r *ResourceHandler) getResource(uri string) (*models.Resource, error) {

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -63,54 +63,54 @@ type ResourceScope struct {
 	resource string
 }
 
-//NewResourceScope returns an empty ResourceScope to fill in calling Project Stage Service or Resource functions
+// NewResourceScope returns an empty ResourceScope to fill in calling Project Stage Service or Resource functions
 func NewResourceScope() *ResourceScope {
 	return &ResourceScope{}
 }
 
-//Project sets the resource scope project value
+// Project sets the resource scope project value
 func (s *ResourceScope) Project(project string) *ResourceScope {
 	s.project = project
 	return s
 }
 
-//Stage sets the resource scope stage value
+// Stage sets the resource scope stage value
 func (s *ResourceScope) Stage(stage string) *ResourceScope {
 	s.stage = stage
 	return s
 }
 
-//Service sets the resource scope service value
+// Service sets the resource scope service value
 func (s *ResourceScope) Service(service string) *ResourceScope {
 	s.service = service
 	return s
 }
 
-//Resource sets the resource scope resource
+// Resource sets the resource scope resource
 func (s *ResourceScope) Resource(resource string) *ResourceScope {
 	s.resource = resource
 	return s
 }
 
-//GetProjectPath returns a string to construct the url to path eg. /<api-version>/project/<project-name>
-// or an empty string if the project is not set
+// GetProjectPath returns a string to construct the url to path eg. /<api-version>/project/<project-name>
+//or an empty string if the project is not set
 func (s *ResourceScope) GetProjectPath() string {
 	return buildPath(v1ProjectPath, s.project)
 }
 
-//GetStagePath returns a string to construct the url to a stage eg. /stage/<stage-name>
+// GetStagePath returns a string to construct the url to a stage eg. /stage/<stage-name>
 //or an empty string if the stage is unset
 func (s *ResourceScope) GetStagePath() string {
 	return buildPath(pathToStage, s.stage)
 }
 
-//GetServicePath returns a string to construct the url to a service eg. /service/<service-name>
+// GetServicePath returns a string to construct the url to a service eg. /service/<service-name>
 //or an empty string if the service is unset
 func (s *ResourceScope) GetServicePath() string {
 	return buildPath(pathToService, url.QueryEscape(s.service))
 }
 
-//GetResourcePath returns a string to construct the url to a resource eg. /resource/<escaped-resource-name>
+// GetResourcePath returns a string to construct the url to a resource eg. /resource/<escaped-resource-name>
 //or /resource if the resource scope is empty
 func (s *ResourceScope) GetResourcePath() string {
 	path := pathToResource
@@ -125,10 +125,10 @@ func (r *ResourceHandler) buildResourceURI(scope ResourceScope) string {
 	return buildURI
 }
 
-// URIOption returns a function that modifies a url
+// URIOption returns a function that modifies an url
 type URIOption func(url string) string
 
-//AppendQuery returns an option function that can modify an URI by appending a map of url query values
+// AppendQuery returns an option function that can modify an URI by appending a map of url query values
 func AppendQuery(queryParams url.Values) URIOption {
 	return func(buildURI string) string {
 		if queryParams != nil {
@@ -190,8 +190,8 @@ func createAuthenticatedResourceHandler(baseURL string, authToken string, authHe
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
 	baseURL = strings.TrimRight(baseURL, "/")
-	if !strings.HasSuffix(baseURL, configurationServiceBaseUrl) {
-		baseURL += "/" + configurationServiceBaseUrl
+	if !strings.HasSuffix(baseURL, configurationServiceBaseURL) {
+		baseURL += "/" + configurationServiceBaseURL
 	}
 	return &ResourceHandler{
 		BaseURL:    baseURL,
@@ -274,7 +274,7 @@ func (r *ResourceHandler) UpdateProjectResources(project string, resources []*mo
 }
 
 // CreateStageResources creates a stage resource
-//Deprecated: use CreateResource instead
+// Deprecated: use CreateResource instead
 func (r *ResourceHandler) CreateStageResources(project string, stage string, resources []*models.Resource) (string, error) {
 	return r.createResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToResource, resources)
 }

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -240,7 +240,7 @@ func (r *ResourceHandler) CreateResources(project string, stage string, service 
 	} else if project != "" && stage != "" && service == "" {
 		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, requestStr, r)
 	} else {
-		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+"/"+pathToResource, requestStr, r)
+		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+"/"+pathToResource, requestStr, r)
 	}
 }
 

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -125,7 +125,7 @@ func (r *ResourceHandler) buildResourceURI(scope ResourceScope) string {
 	return buildURI
 }
 
-// GetOp
+// URIOption returns a function that modifies a url
 type URIOption func(url string) string
 
 //AppendQuery returns an option function that can modify an URI by appending a map of url query values

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -17,7 +17,7 @@ import (
 const pathToResource = "/resource"
 const pathToService = "/service"
 const pathToStage = "/stage"
-const configurationServiceBaseUrl = "configuration-service"
+const configurationServiceBaseURL = "configuration-service"
 
 var ResourceNotFoundError = errors.New("Resource not found")
 

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -236,11 +236,11 @@ func (r *ResourceHandler) CreateResources(project string, stage string, service 
 	}
 
 	if project != "" && stage != "" && service != "" {
-		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToService+"/"+service+pathToResource, requestStr, r)
+		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+service+pathToResource, requestStr, r)
 	} else if project != "" && stage != "" && service == "" {
-		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToResource, requestStr, r)
+		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, requestStr, r)
 	} else {
-		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToResource, requestStr, r)
+		return postWithEventContext(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+"/"+pathToResource, requestStr, r)
 	}
 }
 
@@ -259,7 +259,7 @@ func (r *ResourceHandler) GetProjectResource(project string, resourceURI string)
 // UpdateProjectResource updates a project resource
 // Deprecated: use UpdateResource instead
 func (r *ResourceHandler) UpdateProjectResource(project string, resource *models.Resource) (string, error) {
-	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
+	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // DeleteProjectResource deletes a project resource
@@ -270,13 +270,13 @@ func (r *ResourceHandler) DeleteProjectResource(project string, resourceURI stri
 
 // UpdateProjectResources updates multiple project resources
 func (r *ResourceHandler) UpdateProjectResources(project string, resources []*models.Resource) (string, error) {
-	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToResource, resources)
+	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToResource, resources)
 }
 
 // CreateStageResources creates a stage resource
 // Deprecated: use CreateResource instead
 func (r *ResourceHandler) CreateStageResources(project string, stage string, resources []*models.Resource) (string, error) {
-	return r.createResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToResource, resources)
+	return r.createResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, resources)
 }
 
 // GetStageResource retrieves a stage resource from the configuration service
@@ -289,13 +289,13 @@ func (r *ResourceHandler) GetStageResource(project string, stage string, resourc
 // UpdateStageResource updates a stage resource
 // Deprecated: use UpdateResource instead
 func (r *ResourceHandler) UpdateStageResource(project string, stage string, resource *models.Resource) (string, error) {
-	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
+	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // UpdateStageResources updates multiple stage resources
 // Deprecated: use UpdateResource instead
 func (r *ResourceHandler) UpdateStageResources(project string, stage string, resources []*models.Resource) (string, error) {
-	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToResource, resources)
+	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, resources)
 }
 
 // DeleteStageResource deletes a stage resource
@@ -307,7 +307,7 @@ func (r *ResourceHandler) DeleteStageResource(project string, stage string, reso
 // CreateServiceResources creates a service resource
 // Deprecated: use CreateResource instead
 func (r *ResourceHandler) CreateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error) {
-	return r.createResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToService+"/"+service+pathToResource, resources)
+	return r.createResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+service+pathToResource, resources)
 }
 
 // GetServiceResource retrieves a service resource from the configuration service
@@ -320,12 +320,12 @@ func (r *ResourceHandler) GetServiceResource(project string, stage string, servi
 // UpdateServiceResource updates a service resource
 // Deprecated: use UpdateResource instead
 func (r *ResourceHandler) UpdateServiceResource(project string, stage string, service string, resource *models.Resource) (string, error) {
-	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
+	return r.updateResource(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // UpdateServiceResources updates multiple service resources
 func (r *ResourceHandler) UpdateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error) {
-	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource, resources)
+	return r.updateResources(r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource, resources)
 }
 
 // DeleteServiceResource deletes a service resource

--- a/pkg/api/utils/resourceUtils_test.go
+++ b/pkg/api/utils/resourceUtils_test.go
@@ -21,7 +21,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "",
 			service:  "",
 			resource: "",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/myproject/resource",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/myproject/resource",
 		},
 		{
 			name:     "project resource",
@@ -29,7 +29,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "",
 			service:  "",
 			resource: "metadata.yaml",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/myproject/resource/metadata.yaml",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/myproject/resource/metadata.yaml",
 		},
 		{
 			name:     "stage resource",
@@ -37,7 +37,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "dev",
 			service:  "",
 			resource: "metadata.yaml",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/resource/metadata.yaml",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/sockshop" + pathToStage + "/dev/resource/metadata.yaml",
 		},
 		{
 			name:     "service resource",
@@ -45,7 +45,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "dev",
 			service:  "helloservice",
 			resource: "hello.go",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/hello.go",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/hello.go",
 		},
 		{
 			name:     "service resources",
@@ -53,7 +53,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "dev",
 			service:  "helloservice",
 			resource: "",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource",
 		},
 		{
 			name:     "service resource escape / ",
@@ -61,12 +61,12 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 			stage:    "dev",
 			service:  "helloservice",
 			resource: "helm%2Fhelloservice.tgz",
-			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/helm%252Fhelloservice.tgz",
+			want:     scheme + "://" + configurationServiceBaseURL + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/helm%252Fhelloservice.tgz",
 		},
 	}
 
 	r := &ResourceHandler{
-		BaseURL: configurationServiceBaseUrl,
+		BaseURL: configurationServiceBaseURL,
 		Scheme:  scheme,
 	}
 

--- a/pkg/api/utils/resourceUtils_test.go
+++ b/pkg/api/utils/resourceUtils_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestResourceHandler_buildResourceURI(t *testing.T) {
+	scheme := "https"
+	tests := []struct {
+		name     string
+		project  string
+		stage    string
+		service  string
+		resource string
+		want     string
+	}{
+		{
+			name:     "project resources",
+			project:  "myproject",
+			stage:    "",
+			service:  "",
+			resource: "",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/myproject/resource",
+		},
+		{
+			name:     "project resource",
+			project:  "myproject",
+			stage:    "",
+			service:  "",
+			resource: "metadata.yaml",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/myproject/resource/metadata.yaml",
+		},
+		{
+			name:     "stage resource",
+			project:  "sockshop",
+			stage:    "dev",
+			service:  "",
+			resource: "metadata.yaml",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/resource/metadata.yaml",
+		},
+		{
+			name:     "service resource",
+			project:  "sockshop",
+			stage:    "dev",
+			service:  "helloservice",
+			resource: "hello.go",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/hello.go",
+		},
+		{
+			name:     "service resources",
+			project:  "sockshop",
+			stage:    "dev",
+			service:  "helloservice",
+			resource: "",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource",
+		},
+		{
+			name:     "service resource escape / ",
+			project:  "sockshop",
+			stage:    "dev",
+			service:  "helloservice",
+			resource: "helm%2Fhelloservice.tgz",
+			want:     scheme + "://" + configurationServiceBaseUrl + v1ProjectPath + "/sockshop" + pathToStage + "/dev/service/helloservice/resource/helm%252Fhelloservice.tgz",
+		},
+	}
+
+	r := &ResourceHandler{
+		BaseURL: configurationServiceBaseUrl,
+		Scheme:  scheme,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope := *NewResourceScope(tt.project, tt.stage, tt.service, tt.resource)
+			assert.Equalf(t, tt.want, r.buildResourceURI(scope), "buildResourceURI(%v)", scope)
+		})
+	}
+}

--- a/pkg/api/utils/resourceUtils_test.go
+++ b/pkg/api/utils/resourceUtils_test.go
@@ -72,7 +72,7 @@ func TestResourceHandler_buildResourceURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scope := *NewResourceScope(tt.project, tt.stage, tt.service, tt.resource)
+			scope := *NewResourceScope().Project(tt.project).Service(tt.service).Resource(tt.resource).Stage(tt.stage)
 			assert.Equalf(t, tt.want, r.buildResourceURI(scope), "buildResourceURI(%v)", scope)
 		})
 	}

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -94,7 +94,7 @@ func (s *StageHandler) CreateStage(project string, stageName string) (*models.Ev
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}
-	return postWithEventContext(s.Scheme+"://"+s.BaseURL+pathToProject+project+pathToStage, body, s)
+	return postWithEventContext(s.Scheme+"://"+s.BaseURL+v1ProjectPath+"/"+project+pathToStage, body, s)
 }
 
 // GetAllStages returns a list of all stages.
@@ -105,7 +105,7 @@ func (s *StageHandler) GetAllStages(project string) ([]*models.Stage, error) {
 
 	nextPageKey := ""
 	for {
-		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + pathToProject + project + pathToStage)
+		url, err := url.Parse(s.Scheme + "://" + s.getBaseURL() + v1ProjectPath + "/" + project + pathToStage)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- reverts breaking changes from [here](https://github.com/keptn/go-utils/pull/375/commits/ba5397b5d46f26791220d1ae4af4991190bdf934)
-  deprecates resource functions in favor of a single one per method 

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

keptn/keptn#6349

### Notes
sdk and shipyard interfaces need to be updated again if we do this 👼 
 

