### PR TITLE
fix: Add missing Method to KeptnInterface/APISet

### DIFF
--- a/pkg/api/models/error.go
+++ b/pkg/api/models/error.go
@@ -1,6 +1,9 @@
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"github.com/keptn/go-utils/pkg/common/strutils"
+)
 
 // Error error
 type Error struct {
@@ -32,5 +35,8 @@ func (e *Error) FromJSON(b []byte) error {
 		return err
 	}
 	*e = res
+	if e.Message == nil {
+		e.Message = strutils.Stringp("")
+	}
 	return nil
 }

--- a/pkg/api/utils/apiServiceUtils.go
+++ b/pkg/api/utils/apiServiceUtils.go
@@ -42,7 +42,7 @@ func wrapOtelTransport(base http.RoundTripper) *otelhttp.Transport {
 // skips verifying server certificates and is able to
 // read proxy configuration from environment variables
 //
-// If the givven http.RoundTripper is nil then a new http.Transport
+// If the given http.RoundTripper is nil then a new http.Transport
 // is created, otherwise the given http.RoundTripper is analysed whether it
 // is of type *http.Transport. If so, the respective settings for
 // disabling server certificate verification as well as proxy server support are set

--- a/pkg/api/utils/client.go
+++ b/pkg/api/utils/client.go
@@ -20,9 +20,10 @@ type KeptnInterface interface {
 	ServicesV1() ServicesV1Interface
 	StagesV1() StagesV1Interface
 	UniformV1() UniformV1Interface
+	ShipyardControlV1() ShipyardControlV1Interface
 }
 
-// APISet contains the API utils for all keptn APIs
+// APISet contains the API utils for all Keptn APIs
 type APISet struct {
 	endpointURL            *url.URL
 	apiToken               string
@@ -98,8 +99,8 @@ func (c *APISet) UniformV1() UniformV1Interface {
 	return c.uniformHandler
 }
 
-// ShipyardControlHandlerV1 retrieves the ShipyardControllerHandler
-func (c *APISet) ShipyardControlHandlerV1() *ShipyardControllerHandler {
+// ShipyardControlV1 retrieves the ShipyardControllerHandler
+func (c *APISet) ShipyardControlV1() ShipyardControlV1Interface {
 	return c.shipyardControlHandler
 }
 
@@ -149,7 +150,9 @@ func New(baseURL string, options ...func(*APISet)) (*APISet, error) {
 	}
 	as := &APISet{}
 	for _, o := range options {
-		o(as)
+		if o != nil {
+			o(as)
+		}
 	}
 	as.endpointURL = u
 	as.httpClient = createInstrumentedClientTransport(as.httpClient)

--- a/pkg/api/utils/client_test.go
+++ b/pkg/api/utils/client_test.go
@@ -19,7 +19,7 @@ func TestApiSetCreatesHandlers(t *testing.T) {
 	assert.Equal(t, "http", apiSet.scheme)
 	assert.NotNil(t, apiSet.UniformV1())
 	assert.NotNil(t, apiSet.Endpoint())
-	assert.NotNil(t, apiSet.ShipyardControlHandlerV1())
+	assert.NotNil(t, apiSet.ShipyardControlV1())
 	assert.NotNil(t, apiSet.StagesV1())
 	assert.NotNil(t, apiSet.ServicesV1())
 	assert.NotNil(t, apiSet.SequencesV1())

--- a/pkg/common/testutils/httpclient.go
+++ b/pkg/common/testutils/httpclient.go
@@ -1,0 +1,13 @@
+package testutils
+
+import "net/http"
+
+// HTTPClientMock is mock implementation of http client usable for testing
+type HTTPClientMock struct {
+	DoFunc func(r *http.Request) (*http.Response, error)
+}
+
+// Do calls the DoFunc function set on the HTTPClientMock
+func (h HTTPClientMock) Do(r *http.Request) (*http.Response, error) {
+	return h.DoFunc(r)
+}


### PR DESCRIPTION
This PR 
* just adds a missing method to Keptn interface used for APISet implementations.
* prevents a potential nil pointer panic in models/error.go
* adds a testutil package with a simple HTTP client mock

Adaptions to the CLI are included in this PR: https://github.com/keptn/keptn/pull/6729