### PR TITLE
fix: correct error message in fake/EventSender.AssertSentEventTypes

### DIFF
--- a/pkg/lib/v0_2_0/fake/events.go
+++ b/pkg/lib/v0_2_0/fake/events.go
@@ -3,8 +3,9 @@ package fake
 import (
 	"context"
 	"fmt"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"sync"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 // EventSender fakes the sending of CloudEvents
@@ -38,7 +39,7 @@ func (es *EventSender) Send(ctx context.Context, event cloudevents.Event) error 
 // AssertSentEventTypes checks if the given event types have been passed to the SendEvent function
 func (es *EventSender) AssertSentEventTypes(eventTypes []string) error {
 	if len(es.SentEvents) != len(eventTypes) {
-		return fmt.Errorf("expected %d event, got %d", len(es.SentEvents), len(eventTypes))
+		return fmt.Errorf("expected %d event, got %d", len(eventTypes), len(es.SentEvents))
 	}
 	for index, event := range es.SentEvents {
 		if event.Type() != eventTypes[index] {


### PR DESCRIPTION
## This PR
- Fix error message in `EventSender.AssertSentEventTypes()` when the length of expected and actually sent couldevents type is different.


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
Write a simple go test using AssertSentEventTypes and pass a number of expected events different from the number of actual Send calls, e.g.

```
   ...
   fakeEventSender := &keptnfake.EventSender{}	
    assert.NoError(
		t, fakeEventSender.AssertSentEventTypes(
			[]string{
				"sh.keptn.event.action.started", "sh.keptn.event.action.finished",
			},
		),
	)

```
Before fix:
```
        	Error:      	Received unexpected error:
        	            	expected 0 event, got 2
```
After fix:
```
        	Error:      	Received unexpected error:
        	            	expected 2 event, got 0
```

