### PR TITLE
feat: Provide option to specify readiness condition

### DIFF
--- a/pkg/api/utils/healthCheck.go
+++ b/pkg/api/utils/healthCheck.go
@@ -63,8 +63,8 @@ func (h *healthHandler) healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func RunHealthEndpoint(port string) {
-	h := newHealthHandler()
+func RunHealthEndpoint(port string, opts ...HealthHandlerOption) {
+	h := newHealthHandler(opts...)
 	http.HandleFunc("/health", h.healthCheck)
 	err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
 	if err != nil {

--- a/pkg/api/utils/healthCheck.go
+++ b/pkg/api/utils/healthCheck.go
@@ -22,12 +22,15 @@ func (s *StatusBody) ToJSON() ([]byte, error) {
 
 type HealthHandlerOption func(h *healthHandler)
 
+// WithReadinessConditionFunc allows to specify a function that should determine if the endpoint should return an HTTP 200 (OK), or
+// a 412 (Precondition failed) response
 func WithReadinessConditionFunc(rc ReadinessConditionFunc) HealthHandlerOption {
 	return func(h *healthHandler) {
 		h.readinessConditionFunc = rc
 	}
 }
 
+// WithPath allows to specify the path under which the endpoint should be reachable
 func WithPath(path string) HealthHandlerOption {
 	return func(h *healthHandler) {
 		h.path = path

--- a/pkg/api/utils/healthCheck.go
+++ b/pkg/api/utils/healthCheck.go
@@ -77,6 +77,8 @@ func (h *healthHandler) healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// RunHealthEndpoint starts an http server on the specified port and provides a simple HTTP Get endpoint that can be used for health checks
+// per default, the endpoint will be reachable under the path '/health'
 func RunHealthEndpoint(port string, opts ...HealthHandlerOption) {
 	h := newHealthHandler(opts...)
 	http.HandleFunc(h.path, h.healthCheck)

--- a/pkg/api/utils/healthCheck_test.go
+++ b/pkg/api/utils/healthCheck_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRunHealthEndpoint(t *testing.T) {
+	go RunHealthEndpoint("8080")
+
+	require.Eventually(t, func() bool {
+		get, err := http.Get("http://localhost:8080/health")
+		if err != nil {
+			return false
+		}
+		if get.StatusCode != http.StatusOK {
+			return false
+		}
+		return true
+	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestRunHealthEndpoint_WithReadinessCondition(t *testing.T) {
+	ready := false
+	go RunHealthEndpoint("8080", WithReadinessConditionFunc(func() bool {
+		return ready
+	}))
+
+	require.Eventually(t, func() bool {
+		get, err := http.Get("http://localhost:8080/health")
+		if err != nil {
+			return false
+		}
+		if get.StatusCode != http.StatusPreconditionFailed {
+			return false
+		}
+		return true
+	}, 2*time.Second, 50*time.Millisecond)
+
+	ready = true
+
+	require.Eventually(t, func() bool {
+		get, err := http.Get("http://localhost:8080/health")
+		if err != nil {
+			return false
+		}
+		if get.StatusCode != http.StatusOK {
+			return false
+		}
+		return true
+	}, 2*time.Second, 50*time.Millisecond)
+}

--- a/pkg/api/utils/healthCheck_test.go
+++ b/pkg/api/utils/healthCheck_test.go
@@ -24,12 +24,12 @@ func TestRunHealthEndpoint(t *testing.T) {
 
 func TestRunHealthEndpoint_WithReadinessCondition(t *testing.T) {
 	ready := false
-	go RunHealthEndpoint("8080", WithReadinessConditionFunc(func() bool {
+	go RunHealthEndpoint("8080", WithPath("/ready"), WithReadinessConditionFunc(func() bool {
 		return ready
 	}))
 
 	require.Eventually(t, func() bool {
-		get, err := http.Get("http://localhost:8080/health")
+		get, err := http.Get("http://localhost:8080/ready")
 		if err != nil {
 			return false
 		}
@@ -42,7 +42,7 @@ func TestRunHealthEndpoint_WithReadinessCondition(t *testing.T) {
 	ready = true
 
 	require.Eventually(t, func() bool {
-		get, err := http.Get("http://localhost:8080/health")
+		get, err := http.Get("http://localhost:8080/ready")
 		if err != nil {
 			return false
 		}

--- a/pkg/api/utils/healthCheck_test.go
+++ b/pkg/api/utils/healthCheck_test.go
@@ -52,3 +52,18 @@ func TestRunHealthEndpoint_WithReadinessCondition(t *testing.T) {
 		return true
 	}, 2*time.Second, 50*time.Millisecond)
 }
+
+func TestRunHealthEndpointCustomPath(t *testing.T) {
+	go RunHealthEndpoint("8080", WithPath("/readiness"))
+
+	require.Eventually(t, func() bool {
+		get, err := http.Get("http://localhost:8080/readiness")
+		if err != nil {
+			return false
+		}
+		if get.StatusCode != http.StatusOK {
+			return false
+		}
+		return true
+	}, 2*time.Second, 50*time.Millisecond)
+}


### PR DESCRIPTION
This PR introduces the option to provide a condition for the health endpoint, as well as the path that should be used for that endpoint, using the following options:

```
WithReadinessConditionFunc
WithPath
```