### PR TITLE
fix: Fixed wrong paths for apiutils

### DIFF
--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -162,7 +162,7 @@ func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
 		baseURL += "/api"
 	}
 
-	req, err := http.NewRequest("GET", a.Scheme+"://"+strings.TrimSuffix(baseURL, "/"+shipyardControllerBaseURL)+v1MetadataPath, nil)
+	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -75,15 +75,10 @@ func (a *APIHandler) getHTTPClient() *http.Client {
 
 // SendEvent sends an event to Keptn
 func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.EventContext, *models.Error) {
-	// the endpoint is not hosted by shipyard controller so we strip away the path to the "controlPlane" api
-	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-	// special handling if the auth token is not set: In this situation we assume the handler to be used
-	// "internally", hence we must ensure that the request URL does not contain the /api path (which is only correct
-	// when using the handler outside the system)
-	if a.AuthToken != "" {
-		if !strings.HasSuffix(baseURL, "api") {
-			baseURL += "/api"
-		}
+	baseURL := a.getBaseURL()
+	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
+		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
+		baseURL += "/api"
 	}
 
 	bodyStr, err := event.ToJSON()
@@ -163,15 +158,10 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 
 // GetMetadata retrieve keptn MetaData information
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
-	// the endpoint is not hosted by shipyard controller so we strip away the path to the "controlPlane" api
-	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-	// special handling if the auth token is not set: In this situation we assume the handler to be used
-	// "internally", hence we must ensure that the request URL does not contain the /api path (which is only correct
-	// when using the handler outside the system)
-	if a.AuthToken != "" {
-		if !strings.HasSuffix(baseURL, "api") {
-			baseURL += "/api"
-		}
+	baseURL := a.getBaseURL()
+	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
+		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
+		baseURL += "/api"
 	}
 
 	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -75,11 +75,21 @@ func (a *APIHandler) getHTTPClient() *http.Client {
 
 // SendEvent sends an event to Keptn
 func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.EventContext, *models.Error) {
+	// the endpoint is not hosted by shipyard controller
+	// so we eventually remove the path suffix
+	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
+
+	// the correct path suffix for this endpoint is /api
+	// so we eventually add the it to the baseURL
+	if !strings.HasSuffix(baseURL, "api") {
+		baseURL += "/api"
+	}
+
 	bodyStr, err := event.ToJSON()
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}
-	return postWithEventContext(a.Scheme+"://"+a.getBaseURL()+v1EventPath, bodyStr, a)
+	return postWithEventContext(a.Scheme+"://"+baseURL+v1EventPath, bodyStr, a)
 }
 
 // TriggerEvaluation triggers a new evaluation

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -152,7 +152,17 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 
 // GetMetadata retrieve keptn MetaData information
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
-	req, err := http.NewRequest("GET", a.Scheme+"://"+strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)+v1MetadataPath, nil)
+	// the endpoint is not hosted by shipyard controller
+	// so we eventually remove the path suffix
+	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
+
+	// the correct path suffix for this endpoint is /api
+	// so we eventually add the it to the baseURL
+	if !strings.HasSuffix(baseURL, "api") {
+		baseURL += "/api"
+	}
+
+	req, err := http.NewRequest("GET", a.Scheme+"://"+strings.TrimSuffix(baseURL, "/"+shipyardControllerBaseURL)+v1MetadataPath, nil)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -44,6 +44,10 @@ func NewAuthenticatedAPIHandler(baseURL string, authToken string, authHeader str
 func createAuthenticatedAPIHandler(baseURL string, authToken string, authHeader string, httpClient *http.Client, scheme string) *APIHandler {
 	baseURL = strings.TrimPrefix(baseURL, "http://")
 	baseURL = strings.TrimPrefix(baseURL, "https://")
+	if !strings.HasSuffix(baseURL, shipyardControllerBaseURL) {
+		baseURL += "/" + shipyardControllerBaseURL
+	}
+
 	return &APIHandler{
 		BaseURL:    baseURL,
 		AuthHeader: authHeader,
@@ -84,7 +88,7 @@ func (a *APIHandler) TriggerEvaluation(project, stage, service string, evaluatio
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}
-	return postWithEventContext(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+service+"/evaluation", bodyStr, a)
+	return postWithEventContext(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+service+"/evaluation", bodyStr, a)
 }
 
 // CreateProject creates a new project
@@ -93,7 +97,7 @@ func (a *APIHandler) CreateProject(project models.CreateProject) (string, *model
 	if err != nil {
 		return "", buildErrorResponse(err.Error())
 	}
-	return post(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath, bodyStr, a)
+	return post(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath, bodyStr, a)
 }
 
 // UpdateProject updates project
@@ -102,12 +106,12 @@ func (a *APIHandler) UpdateProject(project models.CreateProject) (string, *model
 	if err != nil {
 		return "", buildErrorResponse(err.Error())
 	}
-	return put(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath, bodyStr, a)
+	return put(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath, bodyStr, a)
 }
 
 // DeleteProject deletes a project
 func (a *APIHandler) DeleteProject(project models.Project) (*models.DeleteProjectResponse, *models.Error) {
-	resp, err := delete(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath+"/"+project.ProjectName, a)
+	resp, err := delete(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath+"/"+project.ProjectName, a)
 	if err != nil {
 		return nil, err
 	}
@@ -127,12 +131,12 @@ func (a *APIHandler) CreateService(project string, service models.CreateService)
 	if err != nil {
 		return "", buildErrorResponse(err.Error())
 	}
-	return post(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath+"/"+project+pathToService, bodyStr, a)
+	return post(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath+"/"+project+pathToService, bodyStr, a)
 }
 
 // DeleteProject deletes a project
 func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServiceResponse, *models.Error) {
-	resp, err := delete(a.Scheme+"://"+a.getBaseURL()+"/"+shipyardControllerBaseURL+v1ProjectPath+"/"+project+pathToService+"/"+service, a)
+	resp, err := delete(a.Scheme+"://"+a.getBaseURL()+v1ProjectPath+"/"+project+pathToService+"/"+service, a)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +152,7 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 
 // GetMetadata retrieve keptn MetaData information
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
-	req, err := http.NewRequest("GET", a.Scheme+"://"+a.getBaseURL()+v1MetadataPath, nil)
+	req, err := http.NewRequest("GET", a.Scheme+"://"+strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)+v1MetadataPath, nil)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())
 	}

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -75,14 +75,15 @@ func (a *APIHandler) getHTTPClient() *http.Client {
 
 // SendEvent sends an event to Keptn
 func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.EventContext, *models.Error) {
-	// the endpoint is not hosted by shipyard controller
-	// so we eventually remove the path suffix
+	// the endpoint is not hosted by shipyard controller so we strip away the path to the "controlPlane" api
 	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-
-	// the correct path suffix for this endpoint is /api
-	// so we eventually add the it to the baseURL
-	if !strings.HasSuffix(baseURL, "api") {
-		baseURL += "/api"
+	// special handling if the auth token is not set: In this situation we assume the handler to be used
+	// "internally", hence we must ensure that the request URL does not contain the /api path (which is only correct
+	// when using the handler outside the system)
+	if a.AuthToken != "" {
+		if !strings.HasSuffix(baseURL, "api") {
+			baseURL += "/api"
+		}
 	}
 
 	bodyStr, err := event.ToJSON()
@@ -162,14 +163,15 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 
 // GetMetadata retrieve keptn MetaData information
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
-	// the endpoint is not hosted by shipyard controller
-	// so we eventually remove the path suffix
+	// the endpoint is not hosted by shipyard controller so we strip away the path to the "controlPlane" api
 	baseURL := strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-
-	// the correct path suffix for this endpoint is /api
-	// so we eventually add the it to the baseURL
-	if !strings.HasSuffix(baseURL, "api") {
-		baseURL += "/api"
+	// special handling if the auth token is not set: In this situation we assume the handler to be used
+	// "internally", hence we must ensure that the request URL does not contain the /api path (which is only correct
+	// when using the handler outside the system)
+	if a.AuthToken != "" {
+		if !strings.HasSuffix(baseURL, "api") {
+			baseURL += "/api"
+		}
 	}
 
 	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)


### PR DESCRIPTION
This PR fixing a potential problem in the `APIHandler` when used with `InternalAPISet`:
Request URIs are not being built correctly: Examples:
* CreateService builds the URI http://shipyardcontroller:8080/controlPlane/v1/project/{PROJECT}/service, rather than http://shipyardcontroller:8080/v1/project/{PROJECT}/service . I.e. would be offered by the shipyard-controller but the URI is wrong.
* GetMetadata builds the URI http://shipyardcontroller:8080/v1/metadata . I.e. is not offered by the shipyard controller, so can't work whatever the URI.