### PR TITLE
fix: Set the path properly for calls to api-service

### DIFF
--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -78,7 +79,6 @@ func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.Eve
 	baseURL := a.getBaseURL()
 	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
 		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-		baseURL += "/api"
 	}
 
 	bodyStr, err := event.ToJSON()
@@ -161,9 +161,9 @@ func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
 	baseURL := a.getBaseURL()
 	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
 		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-		baseURL += "/api"
 	}
 
+	fmt.Printf("API URL: %s", a.Scheme+"://"+baseURL+v1MetadataPath)
 	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -76,10 +76,7 @@ func (a *APIHandler) getHTTPClient() *http.Client {
 
 // SendEvent sends an event to Keptn
 func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.EventContext, *models.Error) {
-	baseURL := a.getBaseURL()
-	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
-		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-	}
+	baseURL := a.getAPIServicePath()
 
 	bodyStr, err := event.ToJSON()
 	if err != nil {
@@ -158,10 +155,7 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 
 // GetMetadata retrieve keptn MetaData information
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
-	baseURL := a.getBaseURL()
-	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
-		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
-	}
+	baseURL := a.getAPIServicePath()
 
 	fmt.Printf("API URL: %s", a.Scheme+"://"+baseURL+v1MetadataPath)
 	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)
@@ -197,4 +191,12 @@ func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
 	}
 
 	return nil, handleErrStatusCode(resp.StatusCode, body)
+}
+
+func (a *APIHandler) getAPIServicePath() string {
+	baseURL := a.getBaseURL()
+	if strings.HasSuffix(baseURL, "/"+shipyardControllerBaseURL) {
+		baseURL = strings.TrimSuffix(a.getBaseURL(), "/"+shipyardControllerBaseURL)
+	}
+	return baseURL
 }

--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -157,7 +156,6 @@ func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServi
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
 	baseURL := a.getAPIServicePath()
 
-	fmt.Printf("API URL: %s", a.Scheme+"://"+baseURL+v1MetadataPath)
 	req, err := http.NewRequest("GET", a.Scheme+"://"+baseURL+v1MetadataPath, nil)
 	if err != nil {
 		return nil, buildErrorResponse(err.Error())

--- a/pkg/api/utils/apiUtils_test.go
+++ b/pkg/api/utils/apiUtils_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestAPIHandler_getAPIServicePath(t *testing.T) {
+	type fields struct {
+		BaseURL string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "remove controlPlane path suffix",
+			fields: fields{
+				BaseURL: "my-api.sh/api/controlPlane",
+			},
+			want: "my-api.sh/api",
+		},
+		{
+			name: "don't modify anything for internal API calls",
+			fields: fields{
+				BaseURL: "api-service",
+			},
+			want: "api-service",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &APIHandler{
+				BaseURL: tt.fields.BaseURL,
+			}
+			assert.Equalf(t, tt.want, a.getAPIServicePath(), "getAPIServicePath()")
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes the logic for adapting the path for calls to the API service.
Previously, calls to the API service were resulting in the following baseURL being used:

`<api-url>/api/api/v1`