### PR TITLE
fix: Make sure all api handlers are set when using v2 api handlers in v1

### DIFF
--- a/pkg/api/utils/apiUtils.go
+++ b/pkg/api/utils/apiUtils.go
@@ -109,40 +109,60 @@ func (a *APIHandler) getHTTPClient() *http.Client {
 
 // SendEvent sends an event to Keptn.
 func (a *APIHandler) SendEvent(event models.KeptnContextExtendedCE) (*models.EventContext, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.SendEvent(context.TODO(), event, v2.APISendEventOptions{})
 }
 
 // TriggerEvaluation triggers a new evaluation.
 func (a *APIHandler) TriggerEvaluation(project, stage, service string, evaluation models.Evaluation) (*models.EventContext, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.TriggerEvaluation(context.TODO(), project, stage, service, evaluation, v2.APITriggerEvaluationOptions{})
 }
 
 // CreateProject creates a new project.
 func (a *APIHandler) CreateProject(project models.CreateProject) (string, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.CreateProject(context.TODO(), project, v2.APICreateProjectOptions{})
 }
 
 // UpdateProject updates a project.
 func (a *APIHandler) UpdateProject(project models.CreateProject) (string, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.UpdateProject(context.TODO(), project, v2.APIUpdateProjectOptions{})
 }
 
 // DeleteProject deletes a project.
 func (a *APIHandler) DeleteProject(project models.Project) (*models.DeleteProjectResponse, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.DeleteProject(context.TODO(), project, v2.APIDeleteProjectOptions{})
 }
 
 // CreateService creates a new service.
 func (a *APIHandler) CreateService(project string, service models.CreateService) (string, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.CreateService(context.TODO(), project, service, v2.APICreateServiceOptions{})
 }
 
 // DeleteService deletes a service.
 func (a *APIHandler) DeleteService(project, service string) (*models.DeleteServiceResponse, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.DeleteService(context.TODO(), project, service, v2.APIDeleteServiceOptions{})
 }
 
 // GetMetadata retrieves Keptn metadata information.
 func (a *APIHandler) GetMetadata() (*models.Metadata, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.apiHandler.GetMetadata(context.TODO(), v2.APIGetMetadataOptions{})
+}
+
+func (a *APIHandler) ensureHandlerIsSet() {
+	if a.apiHandler != nil {
+		return
+	}
+
+	if a.AuthToken != "" {
+		a.apiHandler = v2.NewAuthenticatedAPIHandler(a.BaseURL, a.AuthToken, a.AuthHeader, a.HTTPClient, a.Scheme)
+	} else {
+		a.apiHandler = v2.NewAPIHandlerWithHTTPClient(a.BaseURL, a.HTTPClient)
+	}
 }

--- a/pkg/api/utils/authUtils.go
+++ b/pkg/api/utils/authUtils.go
@@ -79,5 +79,18 @@ func (a *AuthHandler) getHTTPClient() *http.Client {
 
 // Authenticate authenticates the client request against the server.
 func (a *AuthHandler) Authenticate() (*models.EventContext, *models.Error) {
+	a.ensureHandlerIsSet()
 	return a.authHandler.Authenticate(context.TODO(), v2.AuthAuthenticateOptions{})
+}
+
+func (a *AuthHandler) ensureHandlerIsSet() {
+	if a.authHandler != nil {
+		return
+	}
+
+	if a.AuthToken != "" {
+		a.authHandler = v2.NewAuthenticatedAuthHandler(a.BaseURL, a.AuthToken, a.AuthHeader, a.HTTPClient, a.Scheme)
+	} else {
+		a.authHandler = v2.NewAuthHandlerWithHTTPClient(a.BaseURL, a.HTTPClient)
+	}
 }

--- a/pkg/api/utils/logUtils.go
+++ b/pkg/api/utils/logUtils.go
@@ -119,24 +119,41 @@ func (lh *LogHandler) getHTTPClient() *http.Client {
 
 // Log appends the specified logs to the log cache.
 func (lh *LogHandler) Log(logs []models.LogEntry) {
+	lh.ensureHandlerIsSet()
 	lh.logHandler.Log(logs, v2.LogsLogOptions{})
 }
 
 // GetLogs gets logs with the specified parameters.
 func (lh *LogHandler) GetLogs(params models.GetLogsParams) (*models.GetLogsResponse, error) {
+	lh.ensureHandlerIsSet()
 	return lh.logHandler.GetLogs(context.TODO(), params, v2.LogsGetLogsOptions{})
 }
 
 // DeleteLogs deletes logs matching the specified log filter.
 func (lh *LogHandler) DeleteLogs(params models.LogFilter) error {
+	lh.ensureHandlerIsSet()
 	return lh.logHandler.DeleteLogs(context.TODO(), params, v2.LogsDeleteLogsOptions{})
 }
 
 func (lh *LogHandler) Start(ctx context.Context) {
+	lh.ensureHandlerIsSet()
 	lh.logHandler.Start(ctx, v2.LogsStartOptions{})
 }
 
 // Flush flushes the log cache.
 func (lh *LogHandler) Flush() error {
+	lh.ensureHandlerIsSet()
 	return lh.logHandler.Flush(context.TODO(), v2.LogsFlushOptions{})
+}
+
+func (lh *LogHandler) ensureHandlerIsSet() {
+	if lh.logHandler != nil {
+		return
+	}
+
+	if lh.AuthToken != "" {
+		lh.logHandler = v2.NewAuthenticatedLogHandler(lh.BaseURL, lh.AuthToken, lh.AuthHeader, lh.HTTPClient, lh.Scheme)
+	} else {
+		lh.logHandler = v2.NewLogHandlerWithHTTPClient(lh.BaseURL, lh.HTTPClient)
+	}
 }

--- a/pkg/api/utils/projectUtils.go
+++ b/pkg/api/utils/projectUtils.go
@@ -101,25 +101,42 @@ func (p *ProjectHandler) getHTTPClient() *http.Client {
 
 // CreateProject creates a new project.
 func (p *ProjectHandler) CreateProject(project models.Project) (*models.EventContext, *models.Error) {
+	p.ensureHandlerIsSet()
 	return p.projectHandler.CreateProject(context.TODO(), project, v2.ProjectsCreateProjectOptions{})
 }
 
 // DeleteProject deletes a project.
 func (p *ProjectHandler) DeleteProject(project models.Project) (*models.EventContext, *models.Error) {
+	p.ensureHandlerIsSet()
 	return p.projectHandler.DeleteProject(context.TODO(), project, v2.ProjectsDeleteProjectOptions{})
 }
 
 // GetProject returns a project.
 func (p *ProjectHandler) GetProject(project models.Project) (*models.Project, *models.Error) {
+	p.ensureHandlerIsSet()
 	return p.projectHandler.GetProject(context.TODO(), project, v2.ProjectsGetProjectOptions{})
 }
 
 // GetAllProjects returns all projects.
 func (p *ProjectHandler) GetAllProjects() ([]*models.Project, error) {
+	p.ensureHandlerIsSet()
 	return p.projectHandler.GetAllProjects(context.TODO(), v2.ProjectsGetAllProjectsOptions{})
 }
 
 // UpdateConfigurationServiceProject updates a configuration service project.
 func (p *ProjectHandler) UpdateConfigurationServiceProject(project models.Project) (*models.EventContext, *models.Error) {
+	p.ensureHandlerIsSet()
 	return p.projectHandler.UpdateConfigurationServiceProject(context.TODO(), project, v2.ProjectsUpdateConfigurationServiceProjectOptions{})
+}
+
+func (p *ProjectHandler) ensureHandlerIsSet() {
+	if p.projectHandler != nil {
+		return
+	}
+
+	if p.AuthToken != "" {
+		p.projectHandler = v2.NewAuthenticatedProjectHandler(p.BaseURL, p.AuthToken, p.AuthHeader, p.HTTPClient, p.Scheme)
+	} else {
+		p.projectHandler = v2.NewProjectHandlerWithHTTPClient(p.BaseURL, p.HTTPClient)
+	}
 }

--- a/pkg/api/utils/resourceUtils.go
+++ b/pkg/api/utils/resourceUtils.go
@@ -267,17 +267,20 @@ func (r *ResourceHandler) getHTTPClient() *http.Client {
 
 // CreateResources creates a resource for the specified entity.
 func (r *ResourceHandler) CreateResources(project string, stage string, service string, resources []*models.Resource) (*models.EventContext, *models.Error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.CreateResources(context.TODO(), project, stage, service, resources, v2.ResourcesCreateResourcesOptions{})
 }
 
 // CreateProjectResources creates multiple project resources.
 func (r *ResourceHandler) CreateProjectResources(project string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.CreateProjectResources(context.TODO(), project, resources, v2.ResourcesCreateProjectResourcesOptions{})
 }
 
 // GetProjectResource retrieves a project resource from the configuration service.
 // Deprecated: use GetResource instead.
 func (r *ResourceHandler) GetProjectResource(project string, resourceURI string) (*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	buildURI := r.Scheme + "://" + r.BaseURL + v1ProjectPath + "/" + project + pathToResource + "/" + url.QueryEscape(resourceURI)
 	return r.resourceHandler.GetResourceByURI(context.TODO(), buildURI)
 }
@@ -285,29 +288,34 @@ func (r *ResourceHandler) GetProjectResource(project string, resourceURI string)
 // UpdateProjectResource updates a project resource.
 // Deprecated: use UpdateResource instead.
 func (r *ResourceHandler) UpdateProjectResource(project string, resource *models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // DeleteProjectResource deletes a project resource.
 // Deprecated: use DeleteResource instead.
 func (r *ResourceHandler) DeleteProjectResource(project string, resourceURI string) error {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.DeleteResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToResource+"/"+url.QueryEscape(resourceURI))
 }
 
 // UpdateProjectResources updates multiple project resources.
 func (r *ResourceHandler) UpdateProjectResources(project string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateProjectResources(context.TODO(), project, resources, v2.ResourcesUpdateProjectResourcesOptions{})
 }
 
 // CreateStageResources creates a stage resource.
 // Deprecated: use CreateResource instead.
 func (r *ResourceHandler) CreateStageResources(project string, stage string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.CreateResourcesByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, resources)
 }
 
 // GetStageResource retrieves a stage resource from the configuration service.
 // Deprecated: use GetResource instead.
 func (r *ResourceHandler) GetStageResource(project string, stage string, resourceURI string) (*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	buildURI := r.Scheme + "://" + r.BaseURL + v1ProjectPath + "/" + project + pathToStage + "/" + stage + pathToResource + "/" + url.QueryEscape(resourceURI)
 	return r.resourceHandler.GetResourceByURI(context.TODO(), buildURI)
 }
@@ -315,30 +323,35 @@ func (r *ResourceHandler) GetStageResource(project string, stage string, resourc
 // UpdateStageResource updates a stage resource.
 // Deprecated: use UpdateResource instead.
 func (r *ResourceHandler) UpdateStageResource(project string, stage string, resource *models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // UpdateStageResources updates multiple stage resources.
 // Deprecated: use UpdateResource instead.
 func (r *ResourceHandler) UpdateStageResources(project string, stage string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateResourcesByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource, resources)
 }
 
 // DeleteStageResource deletes a stage resource.
 // Deprecated: use DeleteResource instead.
 func (r *ResourceHandler) DeleteStageResource(project string, stage string, resourceURI string) error {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.DeleteResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToResource+"/"+url.QueryEscape(resourceURI))
 }
 
 // CreateServiceResources creates a service resource.
 // Deprecated: use CreateResource instead.
 func (r *ResourceHandler) CreateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.CreateResourcesByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+service+pathToResource, resources)
 }
 
 // GetServiceResource retrieves a service resource from the configuration service.
 // Deprecated: use GetResource instead.
 func (r *ResourceHandler) GetServiceResource(project string, stage string, service string, resourceURI string) (*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	buildURI := r.Scheme + "://" + r.BaseURL + v1ProjectPath + "/" + project + pathToStage + "/" + stage + pathToService + "/" + url.QueryEscape(service) + pathToResource + "/" + url.QueryEscape(resourceURI)
 	return r.resourceHandler.GetResourceByURI(context.TODO(), buildURI)
 }
@@ -346,47 +359,56 @@ func (r *ResourceHandler) GetServiceResource(project string, stage string, servi
 // UpdateServiceResource updates a service resource.
 // Deprecated: use UpdateResource instead.
 func (r *ResourceHandler) UpdateServiceResource(project string, stage string, service string, resource *models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource+"/"+url.QueryEscape(*resource.ResourceURI), resource)
 }
 
 // UpdateServiceResources updates multiple service resources.
 func (r *ResourceHandler) UpdateServiceResources(project string, stage string, service string, resources []*models.Resource) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateServiceResources(context.TODO(), project, stage, service, resources, v2.ResourcesUpdateServiceResourcesOptions{})
 }
 
 // DeleteServiceResource deletes a service resource.
 // Deprecated: use DeleteResource instead.
 func (r *ResourceHandler) DeleteServiceResource(project string, stage string, service string, resourceURI string) error {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.DeleteResourceByURI(context.TODO(), r.Scheme+"://"+r.BaseURL+v1ProjectPath+"/"+project+pathToStage+"/"+stage+pathToService+"/"+url.QueryEscape(service)+pathToResource+"/"+url.QueryEscape(resourceURI))
 }
 
 //GetResource returns a resource from the defined ResourceScope after applying all URI change configured in the options.
 func (r *ResourceHandler) GetResource(scope ResourceScope, options ...URIOption) (*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.GetResource(context.TODO(), toV2ResourceScope(scope), v2.ResourcesGetResourceOptions{URIOptions: toV2URIOptions(options)})
 }
 
 //DeleteResource delete a resource from the URI defined by ResourceScope and modified by the URIOption.
 func (r *ResourceHandler) DeleteResource(scope ResourceScope, options ...URIOption) error {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.DeleteResource(context.TODO(), toV2ResourceScope(scope), v2.ResourcesDeleteResourceOptions{URIOptions: toV2URIOptions(options)})
 }
 
 //UpdateResource updates a resource from the URI defined by ResourceScope and modified by the URIOption.
 func (r *ResourceHandler) UpdateResource(resource *models.Resource, scope ResourceScope, options ...URIOption) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.UpdateResource(context.TODO(), resource, toV2ResourceScope(scope), v2.ResourcesUpdateResourceOptions{URIOptions: toV2URIOptions(options)})
 }
 
 //CreateResource creates one or more resources at the URI defined by ResourceScope and modified by the URIOption.
 func (r *ResourceHandler) CreateResource(resource []*models.Resource, scope ResourceScope, options ...URIOption) (string, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.CreateResource(context.TODO(), resource, toV2ResourceScope(scope), v2.ResourcesCreateResourceOptions{URIOptions: toV2URIOptions(options)})
 }
 
 // GetAllStageResources returns a list of all resources.
 func (r *ResourceHandler) GetAllStageResources(project string, stage string) ([]*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.GetAllStageResources(context.TODO(), project, stage, v2.ResourcesGetAllStageResourcesOptions{})
 }
 
 // GetAllServiceResources returns a list of all resources.
 func (r *ResourceHandler) GetAllServiceResources(project string, stage string, service string) ([]*models.Resource, error) {
+	r.ensureHandlerIsSet()
 	return r.resourceHandler.GetAllServiceResources(context.TODO(), project, stage, service, v2.ResourcesGetAllServiceResourcesOptions{})
 }
 
@@ -408,4 +430,16 @@ func toV2URIOptions(uriOptions []URIOption) []v2.URIOption {
 
 func toV2ResourceScope(scope ResourceScope) v2.ResourceScope {
 	return *(v2.NewResourceScope().Project(scope.project).Stage(scope.stage).Service(scope.service).Resource(scope.resource))
+}
+
+func (r *ResourceHandler) ensureHandlerIsSet() {
+	if r.resourceHandler != nil {
+		return
+	}
+
+	if r.AuthToken != "" {
+		r.resourceHandler = v2.NewAuthenticatedResourceHandler(r.BaseURL, r.AuthToken, r.AuthHeader, r.HTTPClient, r.Scheme)
+	} else {
+		r.resourceHandler = v2.NewResourceHandlerWithHTTPClient(r.BaseURL, r.HTTPClient)
+	}
 }

--- a/pkg/api/utils/secretUtils.go
+++ b/pkg/api/utils/secretUtils.go
@@ -104,20 +104,36 @@ func (s *SecretHandler) getHTTPClient() *http.Client {
 
 // CreateSecret creates a new secret.
 func (s *SecretHandler) CreateSecret(secret models.Secret) error {
+	s.ensureHandlerIsSet()
 	return s.secretHandler.CreateSecret(context.TODO(), secret, v2.SecretsCreateSecretOptions{})
 }
 
 // UpdateSecret creates a new secret.
 func (s *SecretHandler) UpdateSecret(secret models.Secret) error {
+	s.ensureHandlerIsSet()
 	return s.secretHandler.UpdateSecret(context.TODO(), secret, v2.SecretsUpdateSecretOptions{})
 }
 
 // DeleteSecret deletes a secret.
 func (s *SecretHandler) DeleteSecret(secretName, secretScope string) error {
+	s.ensureHandlerIsSet()
 	return s.secretHandler.DeleteSecret(context.TODO(), secretName, secretScope, v2.SecretsDeleteSecretOptions{})
 }
 
 // GetSecrets returns a list of created secrets.
 func (s *SecretHandler) GetSecrets() (*models.GetSecretsResponse, error) {
+	s.ensureHandlerIsSet()
 	return s.secretHandler.GetSecrets(context.TODO(), v2.SecretsGetSecretsOptions{})
+}
+
+func (s *SecretHandler) ensureHandlerIsSet() {
+	if s.secretHandler != nil {
+		return
+	}
+
+	if s.AuthToken != "" {
+		s.secretHandler = v2.NewAuthenticatedSecretHandler(s.BaseURL, s.AuthToken, s.AuthHeader, s.HTTPClient, s.Scheme)
+	} else {
+		s.secretHandler = v2.NewSecretHandlerWithHTTPClient(s.BaseURL, s.HTTPClient)
+	}
 }

--- a/pkg/api/utils/sequenceUtils.go
+++ b/pkg/api/utils/sequenceUtils.go
@@ -132,6 +132,7 @@ func (s *SequenceControlHandler) getHTTPClient() *http.Client {
 }
 
 func (s *SequenceControlHandler) ControlSequence(params SequenceControlParams) error {
+	s.ensureHandlerIsSet()
 	return s.sequenceControlHandler.ControlSequence(
 		context.TODO(),
 		v2.SequenceControlParams{
@@ -141,4 +142,16 @@ func (s *SequenceControlHandler) ControlSequence(params SequenceControlParams) e
 			State:        params.State,
 		},
 		v2.SequencesControlSequenceOptions{})
+}
+
+func (s *SequenceControlHandler) ensureHandlerIsSet() {
+	if s.sequenceControlHandler != nil {
+		return
+	}
+
+	if s.AuthToken != "" {
+		s.sequenceControlHandler = v2.NewAuthenticatedSequenceControlHandler(s.BaseURL, s.AuthToken, s.AuthHeader, s.HTTPClient, s.Scheme)
+	} else {
+		s.sequenceControlHandler = v2.NewSequenceControlHandlerWithHTTPClient(s.BaseURL, s.HTTPClient)
+	}
 }

--- a/pkg/api/utils/serviceUtils.go
+++ b/pkg/api/utils/serviceUtils.go
@@ -96,20 +96,36 @@ func (s *ServiceHandler) getHTTPClient() *http.Client {
 
 // CreateServiceInStage creates a new service.
 func (s *ServiceHandler) CreateServiceInStage(project string, stage string, serviceName string) (*models.EventContext, *models.Error) {
+	s.ensureHandlerIsSet()
 	return s.serviceHandler.CreateServiceInStage(context.TODO(), project, stage, serviceName, v2.ServicesCreateServiceInStageOptions{})
 }
 
 // DeleteServiceFromStage deletes a service from a stage.
 func (s *ServiceHandler) DeleteServiceFromStage(project string, stage string, serviceName string) (*models.EventContext, *models.Error) {
+	s.ensureHandlerIsSet()
 	return s.serviceHandler.DeleteServiceFromStage(context.TODO(), project, stage, serviceName, v2.ServicesDeleteServiceFromStageOptions{})
 }
 
 // GetService gets a service.
 func (s *ServiceHandler) GetService(project, stage, service string) (*models.Service, error) {
+	s.ensureHandlerIsSet()
 	return s.serviceHandler.GetService(context.TODO(), project, stage, service, v2.ServicesGetServiceOptions{})
 }
 
 // GetAllServices returns a list of all services.
 func (s *ServiceHandler) GetAllServices(project string, stage string) ([]*models.Service, error) {
+	s.ensureHandlerIsSet()
 	return s.serviceHandler.GetAllServices(context.TODO(), project, stage, v2.ServicesGetAllServicesOptions{})
+}
+
+func (s *ServiceHandler) ensureHandlerIsSet() {
+	if s.serviceHandler != nil {
+		return
+	}
+
+	if s.AuthToken != "" {
+		s.serviceHandler = v2.NewAuthenticatedServiceHandler(s.BaseURL, s.AuthToken, s.AuthHeader, s.HTTPClient, s.Scheme)
+	} else {
+		s.serviceHandler = v2.NewServiceHandlerWithHTTPClient(s.BaseURL, s.HTTPClient)
+	}
 }

--- a/pkg/api/utils/shipyardControllerUtils.go
+++ b/pkg/api/utils/shipyardControllerUtils.go
@@ -89,5 +89,18 @@ func (s *ShipyardControllerHandler) getHTTPClient() *http.Client {
 
 // GetOpenTriggeredEvents returns all open triggered events.
 func (s *ShipyardControllerHandler) GetOpenTriggeredEvents(filter EventFilter) ([]*models.KeptnContextExtendedCE, error) {
+	s.ensureHandlerIsSet()
 	return s.shipyardControllerHandler.GetOpenTriggeredEvents(context.TODO(), *toV2EventFilter(&filter), v2.ShipyardControlGetOpenTriggeredEventsOptions{})
+}
+
+func (s *ShipyardControllerHandler) ensureHandlerIsSet() {
+	if s.shipyardControllerHandler != nil {
+		return
+	}
+
+	if s.AuthToken != "" {
+		s.shipyardControllerHandler = v2.NewAuthenticatedShipyardControllerHandler(s.BaseURL, s.AuthToken, s.AuthHeader, s.HTTPClient, s.Scheme)
+	} else {
+		s.shipyardControllerHandler = v2.NewShipyardControllerHandlerWithHTTPClient(s.BaseURL, s.HTTPClient)
+	}
 }

--- a/pkg/api/utils/stageUtils.go
+++ b/pkg/api/utils/stageUtils.go
@@ -91,10 +91,24 @@ func (s *StageHandler) getHTTPClient() *http.Client {
 
 // CreateStage creates a new stage with the provided name.
 func (s *StageHandler) CreateStage(project string, stageName string) (*models.EventContext, *models.Error) {
+	s.ensureHandlerIsSet()
 	return s.stageHandler.CreateStage(context.TODO(), project, stageName, v2.StagesCreateStageOptions{})
 }
 
 // GetAllStages returns a list of all stages.
 func (s *StageHandler) GetAllStages(project string) ([]*models.Stage, error) {
+	s.ensureHandlerIsSet()
 	return s.stageHandler.GetAllStages(context.TODO(), project, v2.StagesGetAllStagesOptions{})
+}
+
+func (s *StageHandler) ensureHandlerIsSet() {
+	if s.stageHandler != nil {
+		return
+	}
+
+	if s.AuthToken != "" {
+		s.stageHandler = v2.NewAuthenticatedStageHandler(s.BaseURL, s.AuthToken, s.AuthHeader, s.HTTPClient, s.Scheme)
+	} else {
+		s.stageHandler = v2.NewStageHandlerWithHTTPClient(s.BaseURL, s.HTTPClient)
+	}
 }

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -90,31 +90,31 @@ func (u *UniformHandler) getHTTPClient() *http.Client {
 }
 
 func (u *UniformHandler) Ping(integrationID string) (*models.Integration, error) {
-	u.ensureUniformHandlerIsSet()
+	u.ensureHandlerIsSet()
 	return u.uniformHandler.Ping(context.TODO(), integrationID, v2.UniformPingOptions{})
 }
 
 func (u *UniformHandler) RegisterIntegration(integration models.Integration) (string, error) {
-	u.ensureUniformHandlerIsSet()
+	u.ensureHandlerIsSet()
 	return u.uniformHandler.RegisterIntegration(context.TODO(), integration, v2.UniformRegisterIntegrationOptions{})
 }
 
 func (u *UniformHandler) CreateSubscription(integrationID string, subscription models.EventSubscription) (string, error) {
-	u.ensureUniformHandlerIsSet()
+	u.ensureHandlerIsSet()
 	return u.uniformHandler.CreateSubscription(context.TODO(), integrationID, subscription, v2.UniformCreateSubscriptionOptions{})
 }
 
 func (u *UniformHandler) UnregisterIntegration(integrationID string) error {
-	u.ensureUniformHandlerIsSet()
+	u.ensureHandlerIsSet()
 	return u.uniformHandler.UnregisterIntegration(context.TODO(), integrationID, v2.UniformUnregisterIntegrationOptions{})
 }
 
 func (u *UniformHandler) GetRegistrations() ([]*models.Integration, error) {
-	u.ensureUniformHandlerIsSet()
+	u.ensureHandlerIsSet()
 	return u.uniformHandler.GetRegistrations(context.TODO(), v2.UniformGetRegistrationsOptions{})
 }
 
-func (u *UniformHandler) ensureUniformHandlerIsSet() {
+func (u *UniformHandler) ensureHandlerIsSet() {
 	if u.uniformHandler != nil {
 		return
 	}

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -122,6 +122,6 @@ func (u *UniformHandler) ensureUniformHandlerIsSet() {
 	if u.AuthToken != "" {
 		u.uniformHandler = v2.NewAuthenticatedUniformHandler(u.BaseURL, u.AuthToken, u.AuthHeader, u.HTTPClient, u.Scheme)
 	} else {
-		v2.NewUniformHandlerWithHTTPClient(u.BaseURL, u.HTTPClient)
+		u.uniformHandler = v2.NewUniformHandlerWithHTTPClient(u.BaseURL, u.HTTPClient)
 	}
 }

--- a/pkg/api/utils/uniformUtils.go
+++ b/pkg/api/utils/uniformUtils.go
@@ -90,21 +90,38 @@ func (u *UniformHandler) getHTTPClient() *http.Client {
 }
 
 func (u *UniformHandler) Ping(integrationID string) (*models.Integration, error) {
+	u.ensureUniformHandlerIsSet()
 	return u.uniformHandler.Ping(context.TODO(), integrationID, v2.UniformPingOptions{})
 }
 
 func (u *UniformHandler) RegisterIntegration(integration models.Integration) (string, error) {
+	u.ensureUniformHandlerIsSet()
 	return u.uniformHandler.RegisterIntegration(context.TODO(), integration, v2.UniformRegisterIntegrationOptions{})
 }
 
 func (u *UniformHandler) CreateSubscription(integrationID string, subscription models.EventSubscription) (string, error) {
+	u.ensureUniformHandlerIsSet()
 	return u.uniformHandler.CreateSubscription(context.TODO(), integrationID, subscription, v2.UniformCreateSubscriptionOptions{})
 }
 
 func (u *UniformHandler) UnregisterIntegration(integrationID string) error {
+	u.ensureUniformHandlerIsSet()
 	return u.uniformHandler.UnregisterIntegration(context.TODO(), integrationID, v2.UniformUnregisterIntegrationOptions{})
 }
 
 func (u *UniformHandler) GetRegistrations() ([]*models.Integration, error) {
+	u.ensureUniformHandlerIsSet()
 	return u.uniformHandler.GetRegistrations(context.TODO(), v2.UniformGetRegistrationsOptions{})
+}
+
+func (u *UniformHandler) ensureUniformHandlerIsSet() {
+	if u.uniformHandler != nil {
+		return
+	}
+
+	if u.AuthToken != "" {
+		u.uniformHandler = v2.NewAuthenticatedUniformHandler(u.BaseURL, u.AuthToken, u.AuthHeader, u.HTTPClient, u.Scheme)
+	} else {
+		v2.NewUniformHandlerWithHTTPClient(u.BaseURL, u.HTTPClient)
+	}
 }

--- a/pkg/api/utils/v2/uniformUtils.go
+++ b/pkg/api/utils/v2/uniformUtils.go
@@ -98,9 +98,6 @@ func (u *UniformHandler) Ping(ctx context.Context, integrationID string, opts Un
 		return nil, errors.New("could not ping an invalid IntegrationID")
 	}
 
-	m, _ := json.MarshalIndent(u, "", "  ")
-	fmt.Println(string(m))
-	fmt.Println(u.baseURL)
 	resp, err := put(ctx, u.scheme+"://"+u.getBaseURL()+v1UniformPath+"/"+integrationID+"/ping", nil, u)
 	if err != nil {
 		return nil, errors.New(err.GetMessage())

--- a/pkg/api/utils/v2/uniformUtils.go
+++ b/pkg/api/utils/v2/uniformUtils.go
@@ -98,6 +98,9 @@ func (u *UniformHandler) Ping(ctx context.Context, integrationID string, opts Un
 		return nil, errors.New("could not ping an invalid IntegrationID")
 	}
 
+	m, _ := json.MarshalIndent(u, "", "  ")
+	fmt.Println(m)
+	fmt.Println(u.baseURL)
 	resp, err := put(ctx, u.scheme+"://"+u.getBaseURL()+v1UniformPath+"/"+integrationID+"/ping", nil, u)
 	if err != nil {
 		return nil, errors.New(err.GetMessage())

--- a/pkg/api/utils/v2/uniformUtils.go
+++ b/pkg/api/utils/v2/uniformUtils.go
@@ -99,7 +99,7 @@ func (u *UniformHandler) Ping(ctx context.Context, integrationID string, opts Un
 	}
 
 	m, _ := json.MarshalIndent(u, "", "  ")
-	fmt.Println(m)
+	fmt.Println(string(m))
 	fmt.Println(u.baseURL)
 	resp, err := put(ctx, u.scheme+"://"+u.getBaseURL()+v1UniformPath+"/"+integrationID+"/ping", nil, u)
 	if err != nil {


### PR DESCRIPTION
This PR makes sure the api handler objects are set before they are used. Otherwise we have the danger of breaking something if the v1 API handlers have been initialized directly, instead of via the constructor methods