### PR TITLE
fix: Make GetAllServiceResources compatible with Keptn 0.16.0+

### DIFF
--- a/pkg/api/utils/v2/resourceUtils.go
+++ b/pkg/api/utils/v2/resourceUtils.go
@@ -483,7 +483,7 @@ func (r *ResourceHandler) GetAllStageResources(ctx context.Context, project stri
 // GetAllServiceResources returns a list of all resources.
 func (r *ResourceHandler) GetAllServiceResources(ctx context.Context, project string, stage string, service string, opts ResourcesGetAllServiceResourcesOptions) ([]*models.Resource, error) {
 	myURL, err := url.Parse(r.scheme + "://" + r.getBaseURL() + v1ProjectPath + "/" + project + pathToStage + "/" + stage +
-		pathToService + "/" + service + pathToResource + "/")
+		pathToService + "/" + service + pathToResource)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Removes a trailing `/` from the URL that is created in the `GetAllServiceResources` to fix the resources not found errors in Keptn 0.16.0

### Related Issues
- keptn/keptn#8160

