### PR TITLE
feat: Use NetworkingV1 instead of deprecated ExtensionsV1beta1

### DIFF
--- a/pkg/common/kubeutils/endpoint_provider.go
+++ b/pkg/common/kubeutils/endpoint_provider.go
@@ -24,7 +24,7 @@ func NewKeptnEndpointProvider(useInClusterConfig bool) (*KeptnEndpointProvider, 
 
 // GetKeptnEndpointFromIngress returns the host of ingress object Keptn Installation
 func (a *KeptnEndpointProvider) GetKeptnEndpointFromIngress(ctx context.Context, namespace string, ingressName string) (string, error) {
-	keptnIngress, err := a.clientSet.ExtensionsV1beta1().Ingresses(namespace).Get(ctx, ingressName, metav1.GetOptions{})
+	keptnIngress, err := a.clientSet.NetworkingV1().Ingresses(namespace).Get(ctx, ingressName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/common/kubeutils/endpoint_provider_test.go
+++ b/pkg/common/kubeutils/endpoint_provider_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -28,7 +28,7 @@ func TestKeptnEndpointProvider_GetKeptnEndpointFromIngress_FailClientSet(t *test
 func TestKeptnEndpointProvider_GetKeptnEndpointFromIngress_Invalid(t *testing.T) {
 	kubernetes := fake.NewSimpleClientset()
 	kubernetes.Fake.PrependReactor("get", "ingresses", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &v1beta1.Ingress{Spec: v1beta1.IngressSpec{}}, nil
+		return true, &networkingv1.Ingress{Spec: networkingv1.IngressSpec{}}, nil
 	})
 	keptnEndpointProvider := &KeptnEndpointProvider{clientSet: kubernetes}
 	res, err := keptnEndpointProvider.GetKeptnEndpointFromIngress(context.TODO(), "keptn", "ingress")
@@ -40,9 +40,9 @@ func TestKeptnEndpointProvider_GetKeptnEndpointFromIngress_Invalid(t *testing.T)
 func TestKeptnEndpointProvider_GetKeptnEndpointFromIngress_Valid(t *testing.T) {
 	kubernetes := fake.NewSimpleClientset()
 	kubernetes.Fake.PrependReactor("get", "ingresses", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &v1beta1.Ingress{
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
+		return true, &networkingv1.Ingress{
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
 					{
 						Host: "1.1.1.1",
 					},


### PR DESCRIPTION
Signed-off-by: Nitanshu Vashistha <nitanshu.vzard@gmail.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Replaces the deprecated  "k8s.io/api/extensions/v1beta1" API with "k8s.io/api/networking/v1"

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes [#4432](https://github.com/keptn/keptn/issues/4432)

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

