### PR TITLE
fix: Use authenticated resource handler

### DIFF
--- a/pkg/sdk/internal/api/initializer.go
+++ b/pkg/sdk/internal/api/initializer.go
@@ -44,7 +44,7 @@ func Initialize(env config.EnvConfig, clientFactory HTTPClientGetter, logger log
 		return nil, fmt.Errorf("could not initialize control plane client api: %w", err)
 	}
 	// initialize api handlers and cp-connector components
-	resourceHandler := resourceHandler(env)
+	resourceHandler := api.ResourcesV1().(*keptnapi.ResourceHandler)
 	ss, es, lf := createCPComponents(api, logger, env)
 	controlPlane := controlplane.New(ss, es, lf, controlplane.WithLogger(logger))
 


### PR DESCRIPTION
Currently, the `go-sdk` initializes an unauthenticated `resource-handler` even when executed in a remote execution plane which does not work since it cannot connect.

## This PR

- Reuses the already created authenticated `resource-handler` from the API instead of creating a new  unauthenticated `resource-handler`

### How to test

1. Run a service in the remote execution plane
2. Try to fetch files using `GetResourceHandler().GetResource()`
