### PR TITLE
feat: Introduce skipping of automatic event responses per task handler

### DIFF
--- a/pkg/sdk/keptn.go
+++ b/pkg/sdk/keptn.go
@@ -116,8 +116,9 @@ func (w *nopWG) Wait() {
 	// --
 }
 
-// WithTaskHandler registers a handler which is responsible for processing a .triggered event
-// Deprecated: use WithTaskEventHandler instead
+// WithTaskHandler registers a handler which is responsible for processing a .triggered event.
+// Note, that if you want to have more control on configuring the behavior of the task handler,
+// you can use WithTaskEventHandler instead
 func WithTaskHandler(eventType string, handler TaskHandler, filters ...func(keptnHandle IKeptn, event KeptnEvent) bool) KeptnOption {
 	return WithTaskEventHandler(eventType, handler, TaskHandlerOptions{
 		Filters:               filters,

--- a/pkg/sdk/keptn_fake.go
+++ b/pkg/sdk/keptn_fake.go
@@ -82,6 +82,12 @@ func (f *FakeKeptn) SetAPI(api api.KeptnInterface) {
 	f.Keptn.api = api
 }
 
+func (f *FakeKeptn) AddTaskEventHandler(eventType string, handler TaskHandler, options TaskHandlerOptions) {
+	f.Keptn.taskRegistry.Add(eventType, taskEntry{taskHandler: handler, eventFilters: options.Filters, taskHandlerOpts: options})
+}
+
+// AddTaskEventHandler registers a TaskHandler
+// Deprecated: use AddTaskEventHandler
 func (f *FakeKeptn) AddTaskHandler(eventType string, handler TaskHandler, filters ...func(keptnHandle IKeptn, event KeptnEvent) bool) {
 	f.AddTaskHandlerWithSubscriptionID(eventType, handler, "", filters...)
 }

--- a/pkg/sdk/taskregistry.go
+++ b/pkg/sdk/taskregistry.go
@@ -13,6 +13,8 @@ type taskEntry struct {
 	taskHandler TaskHandler
 	// eventFilters is a list of functions that are executed before a task is handled by the taskHandler. Only if all functions return 'true', the task will be handled
 	eventFilters []func(keptnHandle IKeptn, event KeptnEvent) bool
+	// taskHandlerOpts are the options for the handler
+	taskHandlerOpts TaskHandlerOptions
 }
 
 func newTaskMap() *taskRegistry {


### PR DESCRIPTION
closes https://github.com/keptn/keptn/issues/8718

This PR introduces the possibility to skip automatic event responses (sending of started/finished events by the sdk) on a per task handler basis. 
Usage:
```go
log.Fatal(sdk.NewKeptn(
	serviceName,
	sdk.WithTaskEventHandler(
		echoTriggeredEventType,
		NewEchoHandler(), sdk.TaskHandlerOptions{
			SkipAutomaticResponse: true,
		}),
	sdk.WithLogger(logrus.StandardLogger()),
).Start())
```