### PR TITLE
fix: Fix event handling for duplicated subscriptions in `go-sdk` remote execution plane use case

### DIFF
--- a/pkg/sdk/connector/eventsource/http/utils.go
+++ b/pkg/sdk/connector/eventsource/http/utils.go
@@ -141,6 +141,23 @@ func dedup(elements []string) []string {
 	return result
 }
 
+// subscriptionDiffer checks whether two lists of event subscriptions are different based on the
+// event type they are targeting
+func subscriptionDiffer(s1 []models.EventSubscription, s2 []models.EventSubscription) bool {
+	for _, ns := range s1 {
+		found := false
+		for _, os := range s2 {
+			if os.Event == ns.Event {
+				found = true
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+	return len(s1) != len(s2)
+}
+
 func ToIds(events []*models.KeptnContextExtendedCE) []string {
 	ids := []string{}
 	for _, e := range events {

--- a/pkg/sdk/connector/eventsource/http/utils_test.go
+++ b/pkg/sdk/connector/eventsource/http/utils_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"github.com/keptn/go-utils/pkg/api/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -94,4 +95,86 @@ func TestKeep(t *testing.T) {
 	assert.True(t, cache.Contains("t2", "e3"))
 	assert.False(t, cache.Contains("t2", "e4"))
 	assert.True(t, cache.Contains("t2", "e5"))
+}
+
+func Test_subscriptionDiffer(t *testing.T) {
+	type args struct {
+		new []models.EventSubscription
+		old []models.EventSubscription
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "equal empty",
+			args: args{
+				new: []models.EventSubscription{},
+				old: []models.EventSubscription{},
+			},
+			want: false,
+		},
+		{
+			name: "equal",
+			args: args{
+				new: []models.EventSubscription{{Event: "e1"}},
+				old: []models.EventSubscription{{Event: "e1"}},
+			},
+			want: false,
+		},
+		{
+			name: "differ1",
+			args: args{
+				new: []models.EventSubscription{{Event: "e1"}},
+				old: []models.EventSubscription{{Event: "e2"}},
+			},
+			want: true,
+		},
+		{
+			name: "differ2",
+			args: args{
+				new: []models.EventSubscription{{Event: "e2"}},
+				old: []models.EventSubscription{{Event: "e1"}},
+			},
+			want: true,
+		},
+		{
+			name: "differ3",
+			args: args{
+				new: []models.EventSubscription{{Event: "e2"}, {Event: "e1"}},
+				old: []models.EventSubscription{{Event: "e1"}},
+			},
+			want: true,
+		},
+		{
+			name: "differ4",
+			args: args{
+				new: []models.EventSubscription{},
+				old: []models.EventSubscription{{Event: "e1"}},
+			},
+			want: true,
+		},
+		{
+			name: "differ5",
+			args: args{
+				new: []models.EventSubscription{{Event: "e1"}},
+				old: []models.EventSubscription{},
+			},
+			want: true,
+		},
+		{
+			name: "differ6",
+			args: args{
+				new: []models.EventSubscription{{Event: "e2"}},
+				old: []models.EventSubscription{{Event: "e1"}, {Event: "e1"}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, subscriptionDiffer(tt.args.new, tt.args.old), "subscriptionDiffer(%v, %v)", tt.args.new, tt.args.old)
+		})
+	}
 }

--- a/pkg/sdk/connector/types/types.go
+++ b/pkg/sdk/connector/types/types.go
@@ -11,8 +11,9 @@ type AdditionalSubscriptionData struct {
 }
 
 type EventUpdate struct {
-	KeptnEvent models.KeptnContextExtendedCE
-	MetaData   EventUpdateMetaData
+	KeptnEvent     models.KeptnContextExtendedCE
+	MetaData       EventUpdateMetaData
+	SubscriptionID string // optional
 }
 
 type EventUpdateMetaData struct {

--- a/pkg/sdk/internal/api/initializer.go
+++ b/pkg/sdk/internal/api/initializer.go
@@ -104,7 +104,7 @@ func getHttpScheme(env config.EnvConfig) (string, error) {
 
 func eventSource(apiSet keptnapi.KeptnInterface, logger logger.Logger, env config.EnvConfig) eventsource.EventSource {
 	if env.PubSubConnectionType() == config.ConnectionTypeHTTP {
-		return eventsourceHttp.New(clock.New(), eventsourceHttp.NewEventAPI(apiSet.ShipyardControlV1(), apiSet.APIV1()))
+		return eventsourceHttp.New(clock.New(), eventsourceHttp.NewEventAPI(apiSet.ShipyardControlV1(), apiSet.APIV1()), eventsourceHttp.WithLogger(logger))
 	}
 	natsConnector := nats.New(env.EventBrokerURL, nats.WithLogger(logger))
 	return eventsourceNats.New(natsConnector, eventsourceNats.WithLogger(logger))


### PR DESCRIPTION
fixes https://github.com/keptn/keptn/issues/8875

Additionally, this PR contains logging improvements of the go-sdk, meaning that it will output a log message containing the currently subscribed events. at INFO level only if the current subscriptions have been changed.